### PR TITLE
feat(snapshot): add snapshot-lz4 compression sub-feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `snapshot-lz4` feature — LZ4 compression via `lz4_flex` (pure Rust); `Compression::Lz4` variant; files: `.snap.lz4` / `.json.lz4`
+
 ## [0.2.0] — 2026-05-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,6 +220,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lz4_flex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,6 +259,7 @@ version = "0.2.0"
 dependencies = [
  "bincode",
  "filetime",
+ "lz4_flex",
  "petgraph",
  "serde",
  "serde_json",
@@ -430,6 +440,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ snapshot = [
     "petgraph/serde-1",
 ]
 snapshot-zstd = ["snapshot", "dep:zstd"]
+snapshot-lz4  = ["snapshot", "dep:lz4_flex"]
 
 [dependencies]
 petgraph = { version = "0.8", features = [] }
@@ -31,6 +32,7 @@ serde_json = { version = "1",    optional = true }
 bincode    = { version = "2",    features = ["serde"], optional = true }
 thiserror  = { version = "2",    optional = true }
 zstd       = { version = "0.13", optional = true }
+lz4_flex   = { version = "0.13", optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ let graph = state.get_fresh()?;     // checks key, rebuilds if stale
 | _(default)_ | `cache`, `metrics`, `connect`, `shortest_path`, `mst` |
 | `snapshot` | `snapshot`, `live` |
 | `snapshot-zstd` | zstd compression for snapshots (implies `snapshot`) |
+| `snapshot-lz4` | LZ4 compression for snapshots via `lz4_flex` (implies `snapshot`) |
 
 ```toml
 [dependencies]
@@ -87,8 +88,11 @@ petgraph-live = "0.2"
 # With snapshot:
 petgraph-live = { version = "0.2", features = ["snapshot"] }
 
-# With compression:
+# With zstd compression:
 petgraph-live = { version = "0.2", features = ["snapshot-zstd"] }
+
+# With LZ4 compression (faster decompression, larger files):
+petgraph-live = { version = "0.2", features = ["snapshot-lz4"] }
 ```
 
 ## Motivation

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -110,15 +110,17 @@ mst::kruskal(&graph)                  // impl Iterator<Item = Element<N,E>> — 
 
 ## Module: `snapshot` (feature-gated)
 
-Feature flag: `snapshot`. Optional compression: `snapshot-zstd`.
+Feature flag: `snapshot`. Optional compression: `snapshot-zstd`, `snapshot-lz4`.
 
 ### File naming
 
 ```
 {name}-{sanitized_key}.snap
 {name}-{sanitized_key}.snap.zst
+{name}-{sanitized_key}.snap.lz4
 {name}-{sanitized_key}.json
 {name}-{sanitized_key}.json.zst
+{name}-{sanitized_key}.json.lz4
 ```
 
 Key sanitization: replace chars outside `[a-zA-Z0-9_.-]` with `_`. Same key → same filename → idempotent overwrite.
@@ -131,6 +133,7 @@ pub enum SnapshotFormat { Bincode, Json }
 pub enum Compression {
     None,
     Zstd { level: i32 },  // requires feature "snapshot-zstd"
+    Lz4,                   // requires feature "snapshot-lz4"
 }
 
 pub struct SnapshotConfig {
@@ -262,5 +265,6 @@ Two concurrent `get_fresh()` callers detecting a stale key both call `build_fn`
 | default         | `petgraph 0.8` only                                  |
 | `snapshot`      | `serde`, `serde_json`, `bincode`, `petgraph/serde-1` |
 | `snapshot-zstd` | `snapshot` + `zstd`                                  |
+| `snapshot-lz4`  | `snapshot` + `lz4_flex`                              |
 
 No `nalgebra`, `rand`, `rayon`, or async runtime.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -41,7 +41,7 @@ All four modules. No breaking changes expected after this milestone.
 
 | Feature                                                        | Notes                                                        |
 | -------------------------------------------------------------- | ------------------------------------------------------------ |
-| `snapshot-lz4` sub-feature                                     | Faster compression than zstd for large graphs                |
+| `snapshot-lz4` sub-feature — [spec](specifications/spec-snapshot-lz4.md) / [plan](brainstorming/plan-snapshot-lz4.md) | Faster decompression than zstd; pure Rust (`lz4_flex`) | **done** |
 | Schema versioning helper                                       | `SnapshotMeta::petgraph_live_version` mismatch → caller hook |
 | `list` + `inspect` without loading graph body (JSON streaming) | Skip `"graph"` field entirely using streaming deserializer   |
 

--- a/docs/specifications/README.md
+++ b/docs/specifications/README.md
@@ -10,11 +10,13 @@ Each document covers: purpose, public API, implementation constraints, and test 
 | [spec-algorithms](spec-algorithms.md) | `metrics`, `connect`, `shortest_path`, `mst` |
 | [spec-snapshot](spec-snapshot.md)     | `snapshot` (feature-gated)                   |
 | [spec-live](spec-live.md)             | `live::GraphState<G>` (feature-gated)        |
+| [spec-snapshot-lz4](spec-snapshot-lz4.md) | `snapshot-lz4` compression sub-feature  |
 
 ## Feature flags
 
-| Flag            | Modules unlocked                                         |
-| --------------- | -------------------------------------------------------- |
-| _(default)_     | `cache`, `metrics`, `connect`, `shortest_path`, `mst`    |
-| `snapshot`      | `snapshot`, `live`                                       |
-| `snapshot-zstd` | adds zstd compression to `snapshot` (implies `snapshot`) |
+| Flag              | Modules unlocked                                         |
+| ----------------- | -------------------------------------------------------- |
+| _(default)_       | `cache`, `metrics`, `connect`, `shortest_path`, `mst`    |
+| `snapshot`        | `snapshot`, `live`                                       |
+| `snapshot-zstd`   | adds zstd compression to `snapshot` (implies `snapshot`) |
+| `snapshot-lz4`    | adds LZ4 compression to `snapshot` (implies `snapshot`)  |

--- a/docs/specifications/spec-snapshot-lz4.md
+++ b/docs/specifications/spec-snapshot-lz4.md
@@ -1,0 +1,149 @@
+---
+title: "snapshot-lz4 sub-feature"
+summary: "LZ4 compression for snapshot files via lz4_flex — pure Rust, no C binding, 2–3× faster decompression than zstd for warm-start latency reduction."
+read_when:
+  - Adding or modifying LZ4 compression support in snapshot module
+  - Choosing between snapshot-lz4 and snapshot-zstd
+  - Understanding file extension conventions for compressed snapshots
+status: implemented
+last_updated: "2026-05-02"
+---
+
+# Specification: `snapshot-lz4` sub-feature
+
+**Crate:** `petgraph-live`
+**Feature flag:** `snapshot-lz4` (implies `snapshot`)
+**Status:** pre-implementation
+**Depends on:** `snapshot` module
+
+---
+
+## Purpose
+
+Add LZ4 compression as an alternative to zstd for snapshot files. LZ4
+decompresses 2–3× faster than zstd at the cost of a larger file. The primary
+benefit is reduced warm-start latency — the time to load a snapshot on process
+startup before a `GraphState` or manual `load()` call returns.
+
+---
+
+## When to use each codec
+
+| Scenario | Recommended compression |
+|---|---|
+| Warm start latency matters (server restart, frequent cold start) | `Compression::Lz4` |
+| Disk space or transfer size matters (large graph, many rotations) | `Compression::Zstd { level }` |
+| CI / automated pipeline (rebuild is fast anyway) | `Compression::None` |
+| Default / no opinion | `Compression::None` |
+
+LZ4 and zstd serve different optimisation targets and are not substitutes.
+Both sub-features can be enabled simultaneously; the caller picks the variant
+in `SnapshotConfig::compression`.
+
+---
+
+## Dependency
+
+| Crate | Version | Notes |
+|---|---|---|
+| `lz4_flex` | `0.13` | Pure Rust, no `liblz4` C binding, no `unsafe` by default |
+
+Compile-time cost: small (pure Rust, no sys crate).
+
+---
+
+## Feature flag
+
+```toml
+[features]
+snapshot-lz4 = ["snapshot", "dep:lz4_flex"]
+
+[dependencies]
+lz4_flex = { version = "0.13", optional = true }
+```
+
+---
+
+## `Compression` enum addition
+
+```rust
+pub enum Compression {
+    None,
+    #[cfg(feature = "snapshot-zstd")]
+    Zstd { level: i32 },
+    #[cfg(feature = "snapshot-lz4")]
+    Lz4,
+}
+```
+
+`Lz4` has no parameters — `lz4_flex` does not expose a compression level in
+its default API.
+
+---
+
+## File naming
+
+```
+{name}-{sanitized_key}.snap.lz4    (bincode + lz4)
+{name}-{sanitized_key}.json.lz4    (json + lz4)
+```
+
+Extension detection on load is by filename suffix (same convention as `.snap.zst`).
+
+---
+
+## API
+
+No new public functions. `Compression::Lz4` is used in `SnapshotConfig::compression`:
+
+```rust
+let cfg = SnapshotConfig {
+    dir:         PathBuf::from("/state/snapshots"),
+    name:        "graph".into(),
+    key:         Some(current_key()),
+    format:      SnapshotFormat::Bincode,
+    compression: Compression::Lz4,
+    keep:        3,
+};
+
+snapshot::save(&cfg, &graph)?;
+let g: Option<MyGraph> = snapshot::load(&cfg)?;
+```
+
+`inspect`, `list`, `purge`, `load_or_build` — all work unchanged.
+
+---
+
+## Performance notes
+
+Typical numbers for sequential in-memory compression (not streaming):
+
+| Codec | Compress | Decompress | Ratio vs uncompressed |
+|---|---|---|---|
+| None | — | — | 1× |
+| LZ4 | ~500 MB/s | ~1800 MB/s | 0.5–0.7× |
+| zstd level 3 | ~250 MB/s | ~1000 MB/s | 0.3–0.5× |
+
+For a 10 MB bincode snapshot:
+- LZ4 decompress: ~5 ms
+- zstd decompress: ~10 ms
+- Difference is measurable at startup for large graphs, negligible for small ones.
+
+---
+
+## Test matrix
+
+| Test | Verifies |
+|---|---|
+| `test_lz4_roundtrip` | save + load with `Compression::Lz4` → graph identical |
+| `test_lz4_extension` | saved file has `.snap.lz4` extension |
+| `test_lz4_inspect` | `inspect()` reads meta without loading graph body |
+| combined feature test | `--features snapshot-lz4,snapshot-zstd` compiles and tests clean |
+
+---
+
+## Known constraints
+
+- `lz4_flex::compress_prepend_size` is infallible — wraps directly in `Ok(...)`.
+- `lz4_flex::decompress_size_prepended` can fail on corrupt input — maps to `SnapshotError::CompressionError`.
+- No streaming API — snapshot bytes are loaded fully into memory before decompression (same as zstd path).

--- a/docs/specifications/spec-snapshot.md
+++ b/docs/specifications/spec-snapshot.md
@@ -11,15 +11,17 @@ last_updated: "2026-05-02"
 
 # Specification: `snapshot` module
 
-**Feature flags:** `snapshot` / `snapshot-zstd`
+**Feature flags:** `snapshot` / `snapshot-zstd` / `snapshot-lz4`
 
 ## File naming
 
 ```
 {name}-{sanitized_key}.snap
 {name}-{sanitized_key}.snap.zst
+{name}-{sanitized_key}.snap.lz4
 {name}-{sanitized_key}.json
 {name}-{sanitized_key}.json.zst
+{name}-{sanitized_key}.json.lz4
 ```
 
 `sanitize_key`: replace chars outside `[a-zA-Z0-9_.-]` with `_`. Error if result trims to empty.

--- a/src/snapshot/config.rs
+++ b/src/snapshot/config.rs
@@ -24,6 +24,10 @@ pub enum Compression {
         /// Zstd compression level (1–22). Typical default: 3.
         level: i32,
     },
+    /// LZ4 compression. Requires the `snapshot-lz4` feature.
+    #[cfg_attr(docsrs, doc(cfg(feature = "snapshot-lz4")))]
+    #[cfg(feature = "snapshot-lz4")]
+    Lz4,
 }
 
 /// Configuration for snapshot save/load operations.

--- a/src/snapshot/io.rs
+++ b/src/snapshot/io.rs
@@ -17,6 +17,10 @@ fn extension(format: &SnapshotFormat, compression: &Compression) -> &'static str
         (SnapshotFormat::Bincode, Compression::Zstd { .. }) => ".snap.zst",
         #[cfg(feature = "snapshot-zstd")]
         (SnapshotFormat::Json, Compression::Zstd { .. }) => ".json.zst",
+        #[cfg(feature = "snapshot-lz4")]
+        (SnapshotFormat::Bincode, Compression::Lz4) => ".snap.lz4",
+        #[cfg(feature = "snapshot-lz4")]
+        (SnapshotFormat::Json, Compression::Lz4) => ".json.lz4",
     }
 }
 
@@ -139,6 +143,8 @@ fn compress(cfg: &SnapshotConfig, bytes: Vec<u8>) -> Result<Vec<u8>, SnapshotErr
         #[cfg(feature = "snapshot-zstd")]
         Compression::Zstd { level } => zstd::encode_all(std::io::Cursor::new(bytes), *level)
             .map_err(|e| SnapshotError::CompressionError(e.to_string())),
+        #[cfg(feature = "snapshot-lz4")]
+        Compression::Lz4 => Ok(lz4_flex::compress_prepend_size(&bytes)),
     }
 }
 
@@ -154,12 +160,28 @@ fn decompress(path: &std::path::Path, bytes: Vec<u8>) -> Result<Vec<u8>, Snapsho
             "zstd feature not enabled".into(),
         ));
     }
+    #[cfg(feature = "snapshot-lz4")]
+    if path.extension().is_some_and(|e| e == "lz4") {
+        return lz4_flex::decompress_size_prepended(&bytes)
+            .map_err(|e| SnapshotError::CompressionError(e.to_string()));
+    }
     Ok(bytes)
 }
 
-#[cfg(feature = "snapshot-zstd")]
+#[cfg(all(feature = "snapshot-zstd", feature = "snapshot-lz4"))]
+const SNAP_EXTENSIONS: &[&str] = &[
+    ".snap",
+    ".json",
+    ".snap.zst",
+    ".json.zst",
+    ".snap.lz4",
+    ".json.lz4",
+];
+#[cfg(all(feature = "snapshot-zstd", not(feature = "snapshot-lz4")))]
 const SNAP_EXTENSIONS: &[&str] = &[".snap", ".json", ".snap.zst", ".json.zst"];
-#[cfg(not(feature = "snapshot-zstd"))]
+#[cfg(all(not(feature = "snapshot-zstd"), feature = "snapshot-lz4"))]
+const SNAP_EXTENSIONS: &[&str] = &[".snap", ".json", ".snap.lz4", ".json.lz4"];
+#[cfg(all(not(feature = "snapshot-zstd"), not(feature = "snapshot-lz4")))]
 const SNAP_EXTENSIONS: &[&str] = &[".snap", ".json"];
 
 fn find_snapshot_file(cfg: &SnapshotConfig) -> Result<Option<PathBuf>, SnapshotError> {

--- a/src/snapshot/rotation.rs
+++ b/src/snapshot/rotation.rs
@@ -5,7 +5,14 @@ use crate::snapshot::error::SnapshotError;
 /// Return all snapshot files for `name` in `dir`, sorted ascending by mtime (oldest first).
 pub fn list_snapshot_files(dir: &Path, name: &str) -> Result<Vec<PathBuf>, SnapshotError> {
     let prefix = format!("{}-", name);
-    let extensions = [".snap", ".snap.zst", ".json", ".json.zst"];
+    let extensions = [
+        ".snap",
+        ".snap.zst",
+        ".snap.lz4",
+        ".json",
+        ".json.zst",
+        ".json.lz4",
+    ];
 
     let mut entries: Vec<(std::time::SystemTime, PathBuf)> = std::fs::read_dir(dir)?
         .filter_map(|e| e.ok())

--- a/tests/snapshot.rs
+++ b/tests/snapshot.rs
@@ -468,6 +468,82 @@ fn test_rotation_save_5_keep_3() {
     assert!(keys.contains(&"key5"));
 }
 
+#[cfg(all(feature = "snapshot", feature = "snapshot-lz4"))]
+#[test]
+fn test_lz4_roundtrip() {
+    use petgraph::Graph;
+    use petgraph_live::snapshot::{Compression, SnapshotConfig, SnapshotFormat, load, save};
+    let dir = tempfile::tempdir().unwrap();
+    let cfg = SnapshotConfig {
+        dir: dir.path().to_path_buf(),
+        name: "g".into(),
+        key: Some("lz4_key".into()),
+        format: SnapshotFormat::Bincode,
+        compression: Compression::Lz4,
+        keep: 3,
+    };
+    let mut graph: Graph<u32, ()> = Graph::new();
+    for i in 0..50 {
+        graph.add_node(i);
+    }
+    save(&cfg, &graph).unwrap();
+    let loaded: Graph<u32, ()> = load(&cfg).unwrap().unwrap();
+    assert_eq!(loaded.node_count(), 50);
+}
+
+#[cfg(all(feature = "snapshot", feature = "snapshot-lz4"))]
+#[test]
+fn test_lz4_extension() {
+    use petgraph::Graph;
+    use petgraph_live::snapshot::{Compression, SnapshotConfig, SnapshotFormat, save};
+    let dir = tempfile::tempdir().unwrap();
+    let cfg = SnapshotConfig {
+        dir: dir.path().to_path_buf(),
+        name: "g".into(),
+        key: Some("lz4ext".into()),
+        format: SnapshotFormat::Bincode,
+        compression: Compression::Lz4,
+        keep: 3,
+    };
+    let graph: Graph<u32, ()> = Graph::new();
+    save(&cfg, &graph).unwrap();
+    let files: Vec<_> = std::fs::read_dir(dir.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .collect();
+    assert_eq!(files.len(), 1);
+    assert!(
+        files[0]
+            .file_name()
+            .to_string_lossy()
+            .ends_with(".snap.lz4")
+    );
+}
+
+#[cfg(all(feature = "snapshot", feature = "snapshot-lz4"))]
+#[test]
+fn test_lz4_inspect() {
+    use petgraph::Graph;
+    use petgraph_live::snapshot::{Compression, SnapshotConfig, SnapshotFormat, inspect, save};
+    let dir = tempfile::tempdir().unwrap();
+    let cfg = SnapshotConfig {
+        dir: dir.path().to_path_buf(),
+        name: "g".into(),
+        key: Some("lz4meta".into()),
+        format: SnapshotFormat::Bincode,
+        compression: Compression::Lz4,
+        keep: 3,
+    };
+    let mut graph: Graph<u32, ()> = Graph::new();
+    graph.add_node(7);
+    graph.add_node(8);
+    graph.add_node(9);
+    save(&cfg, &graph).unwrap();
+    let meta = inspect(&cfg).unwrap().unwrap();
+    assert_eq!(meta.node_count, 3);
+    assert_eq!(meta.key, "lz4meta");
+}
+
 #[cfg(all(feature = "snapshot", feature = "snapshot-zstd"))]
 #[test]
 fn test_zstd_roundtrip() {


### PR DESCRIPTION
## Summary

- Adds `lz4_flex`-based LZ4 compression as optional `snapshot-lz4` sub-feature
- New `Compression::Lz4` variant; files: `.snap.lz4` / `.json.lz4`
- 2–3× faster decompression than zstd — reduces warm-start latency for large graphs

## Changes

- `Cargo.toml`: `lz4_flex = { version = "0.13", optional = true }`, feature `snapshot-lz4 = ["snapshot", "dep:lz4_flex"]`
- `src/snapshot/config.rs`: `Compression::Lz4` variant behind `#[cfg(feature = "snapshot-lz4")]`
- `src/snapshot/io.rs`: extension arms, `compress`, `decompress`, `SNAP_EXTENSIONS` updated
- `src/snapshot/rotation.rs`: `.snap.lz4` / `.json.lz4` added to extension list
- `tests/snapshot.rs`: `test_lz4_roundtrip`, `test_lz4_extension`, `test_lz4_inspect`
- Docs: spec, api-design, roadmap, changelog, readme updated

## Test plan

- [x] `cargo test` — 59 passed
- [x] `cargo test --features snapshot` — 104 passed
- [x] `cargo test --features snapshot-zstd` — 105 passed
- [x] `cargo test --features snapshot-lz4` — 107 passed
- [x] `cargo test --features snapshot-zstd,snapshot-lz4` — 108 passed
- [x] `cargo test --doc --all-features` — 32 passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Closes #1