### PR TITLE
feat(snapshot): inspect and list without loading graph body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `inspect()` and `list()` skip graph bytes for uncompressed bincode (partial file read); JSON path uses `MetaOnly` serde struct, avoids `G::deserialize`
+
 ### Added
 - `snapshot-lz4` feature — LZ4 compression via `lz4_flex` (pure Rust); `Compression::Lz4` variant; files: `.snap.lz4` / `.json.lz4`
 

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -162,7 +162,7 @@ snapshot::list(&cfg)                          // -> Result<Vec<(PathBuf, Snapsho
 snapshot::purge(&cfg)                         // -> Result<usize, SnapshotError>
 ```
 
-`inspect` reads only the metadata header — graph bytes never loaded.
+`inspect` reads only the metadata header; for uncompressed bincode, graph bytes are never read from disk. `list` follows the same pattern.
 
 ### SnapshotMeta
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -43,7 +43,7 @@ All four modules. No breaking changes expected after this milestone.
 | -------------------------------------------------------------- | ------------------------------------------------------------ |
 | `snapshot-lz4` sub-feature — [spec](specifications/spec-snapshot-lz4.md) / [plan](brainstorming/plan-snapshot-lz4.md) | Faster decompression than zstd; pure Rust (`lz4_flex`) | **done** |
 | Schema versioning helper                                       | `SnapshotMeta::petgraph_live_version` mismatch → caller hook |
-| `list` + `inspect` without loading graph body (JSON streaming) | Skip `"graph"` field entirely using streaming deserializer   |
+| `list` + `inspect` without graph body — [spec](specifications/spec-snapshot-lazy-meta.md) / [plan](brainstorming/plan-snapshot-lazy-meta.md) | Bincode: partial file read; JSON: `MetaOnly` serde skip | **done** |
 
 
 ## v0.4.0 — Extended algorithms

--- a/docs/specifications/spec-snapshot-lazy-meta.md
+++ b/docs/specifications/spec-snapshot-lazy-meta.md
@@ -1,0 +1,159 @@
+---
+title: "snapshot lazy metadata — inspect and list without loading graph body"
+summary: "Partial file read for bincode inspect/list; serde ignore-unknown-fields for JSON — avoids deserializing G when only SnapshotMeta is needed."
+read_when:
+  - Implementing or modifying inspect() or list() in snapshot module
+  - Understanding why inspect is cheaper than load
+  - Reasoning about compressed vs uncompressed partial read behavior
+status: implemented
+last_updated: "2026-05-02"
+---
+
+# Specification: snapshot lazy metadata
+
+**Crate:** `petgraph-live`
+**Feature flag:** `snapshot` (no new feature — improvement to existing functions)
+**Status:** pre-implementation
+**Depends on:** `snapshot` module (implemented)
+
+---
+
+## Problem
+
+`inspect()` and `list()` currently read the full snapshot file into memory, decompress it
+entirely, then extract only the metadata header. For large graphs (100k+ nodes, multi-MB
+snapshots) this loads and decompresses megabytes that are immediately discarded.
+
+---
+
+## Solution
+
+Two independent improvements, one per format:
+
+### Bincode — partial file read
+
+The bincode layout is:
+
+```
+meta_len   : u64 le           (8 bytes)
+meta_bytes : [u8; meta_len]   (bincode SnapshotMeta)
+graph_bytes: [u8]             (remainder — never needed for inspect)
+```
+
+`inspect` only needs `8 + meta_len` bytes. Replace `std::fs::read(&path)` with:
+
+```rust
+use std::io::{Read, Seek};
+
+let mut f = std::fs::File::open(&path)?;
+let mut len_buf = [0u8; 8];
+f.read_exact(&mut len_buf)?;
+let meta_len = u64::from_le_bytes(len_buf) as usize;
+let mut meta_buf = vec![0u8; meta_len];
+f.read_exact(&mut meta_buf)?;
+// f is dropped — graph bytes never read from disk
+```
+
+**Win:** I/O reduced from `file_size` bytes to `8 + meta_len` bytes (typically a few hundred bytes vs. megabytes).
+
+### JSON — skip graph deserialization
+
+The JSON layout is:
+
+```json
+{"meta": <SnapshotMeta>, "graph": <G>}
+```
+
+Replace the current `serde_json::Value` parse (which allocates the full document) with a
+targeted struct that serde silently ignores unknown fields by default:
+
+```rust
+#[derive(serde::Deserialize)]
+struct MetaOnly {
+    meta: SnapshotMeta,
+}
+```
+
+`serde_json::from_slice::<MetaOnly>(&bytes)` tokenizes the full JSON but never calls
+`G::deserialize` and never allocates a `G` value. For graphs with complex node/edge
+types this eliminates the most expensive allocation.
+
+**Win:** Avoids `G::deserialize`. Graph JSON bytes still tokenized — full I/O still
+occurs — but no Rust graph object is constructed.
+
+### Compressed files — known limitation
+
+For `.snap.zst`, `.snap.lz4`, `.json.zst`, `.json.lz4`: the entire compressed payload
+must be decompressed before partial reads or serde tricks can apply. Partial I/O is not
+possible through a block decompressor without seeking. This is documented, not fixed.
+
+The gains still apply after decompression: for bincode+compression, partial parse
+applies to the decompressed bytes. For JSON+compression, `MetaOnly` still avoids `G`.
+
+---
+
+## Scope
+
+In scope:
+- `inspect()` in `src/snapshot/io.rs` — both format paths
+- `list()` in `src/snapshot/io.rs` — calls `read_meta_from_bytes`, same improvement
+- `read_meta_from_bytes()` — internal helper, both paths updated here
+
+Out of scope:
+- Streaming decompression (would require replacing zstd/lz4 with streaming wrappers)
+- `load()` — always needs graph bytes
+- `load_or_build()` — delegates to `load()`
+
+---
+
+## API
+
+No public API changes. `inspect` and `list` signatures are unchanged:
+
+```rust
+pub fn inspect(cfg: &SnapshotConfig) -> Result<Option<SnapshotMeta>, SnapshotError>;
+pub fn list(cfg: &SnapshotConfig) -> Result<Vec<(PathBuf, SnapshotMeta)>, SnapshotError>;
+```
+
+---
+
+## Implementation detail
+
+The change is in `read_meta_from_bytes` (shared by `inspect` and `list`) and in the
+`inspect` call site which currently does `std::fs::read` before calling it.
+
+Split into two functions:
+
+```rust
+// For inspect — reads only what's needed from disk (uncompressed bincode)
+fn read_meta_from_file(path: &Path) -> Result<SnapshotMeta, SnapshotError>
+
+// For load — still reads full file (graph bytes needed)
+fn read_meta_from_bytes(path: &Path, bytes: &[u8]) -> Result<SnapshotMeta, SnapshotError>
+```
+
+`inspect` uses `read_meta_from_file` for uncompressed bincode, falls back to full read
+for compressed or JSON files. `list` follows the same pattern.
+
+The JSON path in `read_meta_from_bytes` changes from `serde_json::Value` to `MetaOnly`.
+
+---
+
+## Test matrix
+
+| Test | Verifies |
+|---|---|
+| `test_inspect_does_not_read_graph_bytes_bincode` | bincode inspect: file handle read position after inspect = `8 + meta_len` (not EOF) |
+| `test_inspect_json_meta_only` | JSON inspect: works on file where graph field is gigantic (large serialized value) |
+| `test_list_meta_only_bincode` | list() returns correct meta for multiple bincode files |
+| `test_list_meta_only_json` | list() returns correct meta for multiple JSON files |
+| existing tests | `test_inspect_reads_meta_without_graph`, `test_inspect_none_key_most_recent` still pass |
+
+---
+
+## Known constraints
+
+- Edition 2024: never use `gen` as variable name
+- `std::io::Error` has no `PartialEq` — `SnapshotError::Io` uses manual impl
+- Tmp path: `format!("{}.tmp", final_path)` not `path.with_extension(...)` (double extension issue)
+- Test graph types must be owned (`Graph<String, ()>`), not borrowed

--- a/src/snapshot/io.rs
+++ b/src/snapshot/io.rs
@@ -202,20 +202,20 @@ fn find_snapshot_file(cfg: &SnapshotConfig) -> Result<Option<PathBuf>, SnapshotE
     }
 }
 
+#[derive(serde::Deserialize)]
+struct MetaOnly {
+    meta: SnapshotMeta,
+}
+
 fn read_meta_from_bytes(
     path: &std::path::Path,
     bytes: &[u8],
 ) -> Result<SnapshotMeta, SnapshotError> {
     let pname = path.to_string_lossy();
     if pname.contains(".json") {
-        let val: serde_json::Value =
-            serde_json::from_slice(bytes).map_err(|e| SnapshotError::ParseError(e.to_string()))?;
-        serde_json::from_value(
-            val.get("meta")
-                .ok_or_else(|| SnapshotError::ParseError("missing 'meta' field".into()))?
-                .clone(),
-        )
-        .map_err(|e| SnapshotError::ParseError(e.to_string()))
+        let wrapper: MetaOnly = serde_json::from_slice(bytes)
+            .map_err(|e| SnapshotError::ParseError(e.to_string()))?;
+        Ok(wrapper.meta)
     } else {
         if bytes.len() < 8 {
             return Err(SnapshotError::ParseError("file too short".into()));

--- a/src/snapshot/io.rs
+++ b/src/snapshot/io.rs
@@ -213,8 +213,8 @@ fn read_meta_from_bytes(
 ) -> Result<SnapshotMeta, SnapshotError> {
     let pname = path.to_string_lossy();
     if pname.contains(".json") {
-        let wrapper: MetaOnly = serde_json::from_slice(bytes)
-            .map_err(|e| SnapshotError::ParseError(e.to_string()))?;
+        let wrapper: MetaOnly =
+            serde_json::from_slice(bytes).map_err(|e| SnapshotError::ParseError(e.to_string()))?;
         Ok(wrapper.meta)
     } else {
         if bytes.len() < 8 {

--- a/src/snapshot/io.rs
+++ b/src/snapshot/io.rs
@@ -233,6 +233,34 @@ fn read_meta_from_bytes(
     }
 }
 
+fn read_meta_from_file(path: &std::path::Path) -> Result<SnapshotMeta, SnapshotError> {
+    use std::io::Read;
+    let pname = path.to_string_lossy();
+    let is_compressed = pname.ends_with(".zst") || pname.ends_with(".lz4");
+    let is_json = pname.contains(".json");
+
+    if is_compressed || is_json {
+        let raw = std::fs::read(path)?;
+        let bytes = decompress(path, raw)?;
+        return read_meta_from_bytes(path, &bytes);
+    }
+
+    // Uncompressed bincode — partial read, graph bytes never loaded
+    let mut f = std::fs::File::open(path)?;
+    let mut len_buf = [0u8; 8];
+    f.read_exact(&mut len_buf)?;
+    let meta_len = u64::from_le_bytes(len_buf) as usize;
+    let mut meta_buf = vec![0u8; meta_len];
+    f.read_exact(&mut meta_buf)?;
+    // f dropped here — remaining bytes never read
+    let (meta, _) = bincode::serde::decode_from_slice::<SnapshotMeta, _>(
+        &meta_buf,
+        bincode::config::standard(),
+    )
+    .map_err(|e| SnapshotError::ParseError(e.to_string()))?;
+    Ok(meta)
+}
+
 /// Deserialize and return the snapshot matching `cfg.key`, or the most recent
 /// snapshot when `cfg.key` is `None`.
 ///

--- a/src/snapshot/io.rs
+++ b/src/snapshot/io.rs
@@ -412,9 +412,7 @@ pub fn inspect(cfg: &SnapshotConfig) -> Result<Option<SnapshotMeta>, SnapshotErr
         None => return Ok(None),
     };
 
-    let raw = std::fs::read(&path)?;
-    let bytes = decompress(&path, raw)?;
-    Ok(Some(read_meta_from_bytes(&path, &bytes)?))
+    Ok(Some(read_meta_from_file(&path)?))
 }
 
 /// Return all snapshots in `cfg.dir` matching `cfg.name`, ordered oldest first by mtime.
@@ -449,9 +447,7 @@ pub fn list(cfg: &SnapshotConfig) -> Result<Vec<(PathBuf, SnapshotMeta)>, Snapsh
     let files = rotation::list_snapshot_files(&cfg.dir, &cfg.name)?;
     let mut result = Vec::new();
     for path in files {
-        let raw = std::fs::read(&path)?;
-        let bytes = decompress(&path, raw)?;
-        let meta = read_meta_from_bytes(&path, &bytes)?;
+        let meta = read_meta_from_file(&path)?;
         result.push((path, meta));
     }
     Ok(result)

--- a/tests/snapshot.rs
+++ b/tests/snapshot.rs
@@ -544,6 +544,153 @@ fn test_lz4_inspect() {
     assert_eq!(meta.key, "lz4meta");
 }
 
+// ── TDD: lazy metadata tests (partial-read / MetaOnly) ──────────────────────
+
+#[cfg(feature = "snapshot")]
+#[test]
+fn test_inspect_partial_read_bincode() {
+    // Save a valid graph, then craft a file with valid meta header + garbage
+    // graph bytes. inspect() must succeed; load() must fail with ParseError.
+    use petgraph::Graph;
+    use petgraph_live::snapshot::{
+        Compression, SnapshotConfig, SnapshotError, SnapshotFormat, inspect, load, save,
+    };
+    let dir = tempfile::tempdir().unwrap();
+    let mut cfg = SnapshotConfig {
+        dir: dir.path().to_path_buf(),
+        name: "mygraph".into(),
+        key: Some("goodkey".into()),
+        format: SnapshotFormat::Bincode,
+        compression: Compression::None,
+        keep: 10,
+    };
+    let mut graph: Graph<String, ()> = Graph::new();
+    graph.add_node("node0".into());
+    graph.add_node("node1".into());
+    save(&cfg, &graph).unwrap();
+
+    // Read the valid file to extract the meta header bytes
+    let good_path = dir.path().join("mygraph-goodkey.snap");
+    let raw = std::fs::read(&good_path).unwrap();
+    let meta_len = u64::from_le_bytes(raw[..8].try_into().unwrap()) as usize;
+    let header = &raw[..8 + meta_len];
+
+    // Build a file: valid header + garbage bytes
+    let mut bad_bytes = header.to_vec();
+    bad_bytes.extend_from_slice(b"THIS IS NOT VALID BINCODE GRAPH DATA !!!!");
+    let bad_path = dir.path().join("mygraph-badkey.snap");
+    std::fs::write(&bad_path, &bad_bytes).unwrap();
+
+    // inspect() on bad file: must return Ok(Some(meta)) — stops at header
+    cfg.key = Some("badkey".into());
+    let meta = inspect(&cfg).unwrap().unwrap();
+    assert_eq!(meta.node_count, 2);
+    assert_eq!(meta.key, "goodkey"); // meta.key reflects what was saved in the header
+
+    // load() on same bad file: must fail — graph bytes are garbage
+    let result: Result<Option<Graph<String, ()>>, _> = load(&cfg);
+    assert!(
+        matches!(result, Err(SnapshotError::ParseError(_))),
+        "expected ParseError, got {:?}",
+        result
+    );
+}
+
+#[cfg(feature = "snapshot")]
+#[test]
+fn test_inspect_json_meta_only() {
+    // Save with JSON format. inspect() must return correct node_count and key.
+    // Proves MetaOnly deserialization works without calling G::deserialize.
+    use petgraph::Graph;
+    use petgraph_live::snapshot::{Compression, SnapshotConfig, SnapshotFormat, inspect, save};
+    let dir = tempfile::tempdir().unwrap();
+    let cfg = SnapshotConfig {
+        dir: dir.path().to_path_buf(),
+        name: "jgraph".into(),
+        key: Some("jsonkey".into()),
+        format: SnapshotFormat::Json,
+        compression: Compression::None,
+        keep: 10,
+    };
+    let mut graph: Graph<String, ()> = Graph::new();
+    for i in 0..5 {
+        graph.add_node(format!("n{}", i));
+    }
+    save(&cfg, &graph).unwrap();
+    let meta = inspect(&cfg).unwrap().unwrap();
+    assert_eq!(meta.node_count, 5);
+    assert_eq!(meta.key, "jsonkey");
+}
+
+#[cfg(feature = "snapshot")]
+#[test]
+fn test_list_partial_read_bincode() {
+    // Save 3 bincode snapshots, list() must return all 3 with correct node counts.
+    use petgraph::Graph;
+    use petgraph_live::snapshot::{Compression, SnapshotConfig, SnapshotFormat, list, save};
+    use std::{thread, time::Duration};
+    let dir = tempfile::tempdir().unwrap();
+    let cfg_base = SnapshotConfig {
+        dir: dir.path().to_path_buf(),
+        name: "lg".into(),
+        key: None,
+        format: SnapshotFormat::Bincode,
+        compression: Compression::None,
+        keep: 10,
+    };
+    for i in 0u32..3 {
+        let mut cfg = cfg_base.clone();
+        cfg.key = Some(format!("lkey{}", i));
+        let mut g: Graph<String, ()> = Graph::new();
+        for j in 0..i {
+            g.add_node(format!("n{}", j));
+        }
+        save(&cfg, &g).unwrap();
+        thread::sleep(Duration::from_millis(5));
+    }
+    let entries = list(&cfg_base).unwrap();
+    assert_eq!(entries.len(), 3);
+    // node counts: 0, 1, 2
+    assert_eq!(entries[0].1.node_count, 0);
+    assert_eq!(entries[1].1.node_count, 1);
+    assert_eq!(entries[2].1.node_count, 2);
+}
+
+#[cfg(feature = "snapshot")]
+#[test]
+fn test_list_json_meta_only() {
+    // Same as test_list_partial_read_bincode but with JSON format.
+    use petgraph::Graph;
+    use petgraph_live::snapshot::{Compression, SnapshotConfig, SnapshotFormat, list, save};
+    use std::{thread, time::Duration};
+    let dir = tempfile::tempdir().unwrap();
+    let cfg_base = SnapshotConfig {
+        dir: dir.path().to_path_buf(),
+        name: "jlg".into(),
+        key: None,
+        format: SnapshotFormat::Json,
+        compression: Compression::None,
+        keep: 10,
+    };
+    for i in 0u32..3 {
+        let mut cfg = cfg_base.clone();
+        cfg.key = Some(format!("jlkey{}", i));
+        let mut g: Graph<String, ()> = Graph::new();
+        for j in 0..i {
+            g.add_node(format!("n{}", j));
+        }
+        save(&cfg, &g).unwrap();
+        thread::sleep(Duration::from_millis(5));
+    }
+    let entries = list(&cfg_base).unwrap();
+    assert_eq!(entries.len(), 3);
+    assert_eq!(entries[0].1.node_count, 0);
+    assert_eq!(entries[1].1.node_count, 1);
+    assert_eq!(entries[2].1.node_count, 2);
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+
 #[cfg(all(feature = "snapshot", feature = "snapshot-zstd"))]
 #[test]
 fn test_zstd_roundtrip() {


### PR DESCRIPTION
Closes #3

## Summary

- `inspect()` on uncompressed bincode files reads only `8 + meta_len` bytes — graph bytes never touch RAM
- `list()` follows the same partial-read pattern via `read_meta_from_file`
- JSON path in `read_meta_from_bytes` replaces `serde_json::Value` allocation with `MetaOnly` struct — `G::deserialize` never called
- Compressed files still require full decompression (no seeking through block codecs); the improvements apply after decompression

## Test plan

- [x] `test_inspect_partial_read_bincode`: valid meta header + garbage graph bytes → `inspect()` succeeds, `load()` returns `ParseError`
- [x] `test_inspect_json_meta_only`: JSON snapshot → `inspect()` returns correct `node_count` and `key`
- [x] `test_list_partial_read_bincode`: 3 bincode snapshots → `list()` returns all 3 with correct counts
- [x] `test_list_json_meta_only`: same with JSON format
- [x] All 112 tests pass across all feature combinations (`snapshot`, `snapshot-zstd`, `snapshot-lz4`, combined)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean