### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-- `inspect()` and `list()` skip graph bytes for uncompressed bincode (partial file read); JSON path uses `MetaOnly` serde struct, avoids `G::deserialize`
+## [0.3.0] — 2026-05-02
 
 ### Added
 - `snapshot-lz4` feature — LZ4 compression via `lz4_flex` (pure Rust); `Compression::Lz4` variant; files: `.snap.lz4` / `.json.lz4`
+- `inspect()` and `list()` no longer read graph bytes for uncompressed bincode files; JSON path skips `G::deserialize` via `MetaOnly` serde helper
 
 ## [0.2.0] — 2026-05-02
 
@@ -40,4 +40,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SECURITY.md`, `docs/release.md`, `docs/specifications/` index,
   `docs/roadmap.md`, `docs/api-design.md`
 
+[0.3.0]: https://github.com/geronimo-iia/petgraph-live/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/geronimo-iia/petgraph-live/releases/tag/v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "petgraph-live"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bincode",
  "filetime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "petgraph-live"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.95"
 description = "Generic generation-keyed graph cache, disk snapshot, and graph algorithms for petgraph 0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,7 @@ required-features = ["snapshot"]
 [[example]]
 name = "live_basic"
 required-features = ["snapshot"]
+
+[[example]]
+name = "snapshot_compression"
+required-features = ["snapshot"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # petgraph-live
 
-> **Status: v0.2.0.** All modules implemented. API not yet stable.
+> **Status: v0.3.0.** All modules implemented. API not yet stable.
 
 Graph cache, snapshot, and algorithms for [`petgraph`](https://docs.rs/petgraph) 0.8.
 
@@ -53,13 +53,18 @@ With snapshot (requires `features = ["snapshot"]`):
 
 ```rust
 use petgraph_live::live::{GraphState, GraphStateConfig};
-use petgraph_live::snapshot::SnapshotConfig;
+use petgraph_live::snapshot::{Compression, SnapshotConfig, SnapshotFormat};
+
+// LZ4 compression — requires `features = ["snapshot-lz4"]`
+#[cfg(feature = "snapshot-lz4")]
+let compression = Compression::Lz4;
 
 let config = GraphStateConfig::new(SnapshotConfig {
     dir: "/tmp/my-cache".into(),
     name: "wiki".into(),
     keep: 3,
-    format: Default::default(),
+    format: SnapshotFormat::Bincode,
+    compression: Compression::None,
     key: None,  // managed internally
 });
 
@@ -83,16 +88,16 @@ let graph = state.get_fresh()?;     // checks key, rebuilds if stale
 
 ```toml
 [dependencies]
-petgraph-live = "0.2"
+petgraph-live = "0.3"
 
 # With snapshot:
-petgraph-live = { version = "0.2", features = ["snapshot"] }
+petgraph-live = { version = "0.3", features = ["snapshot"] }
 
 # With zstd compression:
-petgraph-live = { version = "0.2", features = ["snapshot-zstd"] }
+petgraph-live = { version = "0.3", features = ["snapshot-zstd"] }
 
 # With LZ4 compression (faster decompression, larger files):
-petgraph-live = { version = "0.2", features = ["snapshot-lz4"] }
+petgraph-live = { version = "0.3", features = ["snapshot-lz4"] }
 ```
 
 ## Motivation

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 | Version | Supported |
 |---------|-----------|
-| 0.2.x   | ✓         |
+| 0.3.x   | ✓         |
 
 ## Reporting a Vulnerability
 

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -1,6 +1,6 @@
 # petgraph-live — API Design
 
-**Version target:** 0.1.0
+**Version target:** 0.3.0
 
 ## Crate structure
 
@@ -247,7 +247,7 @@ state.generation()   // -> u64 (process-lifetime counter)
 (microseconds). Concurrent `get()` callers are never blocked during a rebuild.
 
 Two concurrent `get_fresh()` callers detecting a stale key both call `build_fn`
-(last writer wins). Acceptable for v0.1 — coalescing deferred to v0.2.
+(last writer wins). Coalescing deferred to a future version.
 
 ## Error handling
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -54,7 +54,7 @@ cargo test --features snapshot-zstd,snapshot-lz4
 - [ ] All tests pass (all three feature combinations above)
 - [ ] Formatted: `cargo fmt -- --check`
 - [ ] No lint issues: `cargo clippy --all-targets --all-features -- -D warnings`
-- [ ] Examples compile: `cargo build --examples --all-features`
+- [ ] Examples compile and run without panic: `cargo run --example cache_basic && cargo run --example connect && cargo run --example metrics && cargo run --example mst && cargo run --example shortest_path && cargo run --example snapshot_basic --features snapshot && cargo run --example live_basic --features snapshot`
 - [ ] Doc tests pass: `cargo test --doc --all-features`
 
 ### Documentation

--- a/docs/release.md
+++ b/docs/release.md
@@ -74,21 +74,24 @@ cargo test --features snapshot-zstd,snapshot-lz4
 ```bash
 # 1. Bump version in Cargo.toml, update CHANGELOG date
 
-# 2. Commit on release branch
+# 2. Commit on release branch, push, open PR
 git commit -am "chore: release vx.y.z"
+git push origin release/vx.y.z
+gh pr create --title "chore: release vx.y.z" --base main
 
-# 3. Merge to main, then tag
+# 3. Wait for PR CI to pass, then merge to main
 git checkout main
 git merge --no-ff release/vx.y.z
+
+# 4. Tag the merge commit and push — GitHub Actions handles publish
 git tag -a vx.y.z -m "Release vx.y.z"
 git push origin main
 git push origin vx.y.z
-
 # GitHub Actions handles publish on tag push
 ```
 
-Tags containing `-rc` (e.g. `v0.2.0-rc1`) follow the same steps but skip
-`cargo publish` — release candidate for testing only.
+Tags containing `-rc` (e.g. `v0.3.0-rc1`) follow the same steps but the
+publish workflow will not trigger (RC tags are excluded).
 
 ## Hotfix
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -6,13 +6,16 @@ Published to [crates.io](https://crates.io/crates/petgraph-live).
 
 ```toml
 [dependencies]
-petgraph-live = "0.2"
+petgraph-live = "0.3"
 
 # With snapshot support:
-petgraph-live = { version = "0.2", features = ["snapshot"] }
+petgraph-live = { version = "0.3", features = ["snapshot"] }
 
 # With zstd compression:
-petgraph-live = { version = "0.2", features = ["snapshot-zstd"] }
+petgraph-live = { version = "0.3", features = ["snapshot-zstd"] }
+
+# With LZ4 compression:
+petgraph-live = { version = "0.3", features = ["snapshot-lz4"] }
 ```
 
 ## Branch Strategy
@@ -42,6 +45,8 @@ active `release/` branch if one is open.
 cargo test
 cargo test --features snapshot
 cargo test --features snapshot-zstd
+cargo test --features snapshot-lz4
+cargo test --features snapshot-zstd,snapshot-lz4
 ```
 
 ### Code quality
@@ -49,7 +54,6 @@ cargo test --features snapshot-zstd
 - [ ] All tests pass (all three feature combinations above)
 - [ ] Formatted: `cargo fmt -- --check`
 - [ ] No lint issues: `cargo clippy --all-targets --all-features -- -D warnings`
-- [ ] No vulnerabilities: `cargo audit`
 - [ ] Examples compile: `cargo build --examples --all-features`
 - [ ] Doc tests pass: `cargo test --doc --all-features`
 
@@ -80,8 +84,7 @@ git tag -a vx.y.z -m "Release vx.y.z"
 git push origin main
 git push origin vx.y.z
 
-# 4. Publish to crates.io
-cargo publish
+# GitHub Actions handles publish on tag push
 ```
 
 Tags containing `-rc` (e.g. `v0.2.0-rc1`) follow the same steps but skip

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # petgraph-live — Roadmap
 
-**Current status:** v0.2.0 implemented. All four modules done; release pending.
+**Current status:** v0.3.0 released. Snapshot improvements complete.
 
 
 ## v0.2.0 — Core

--- a/docs/specifications/README.md
+++ b/docs/specifications/README.md
@@ -11,6 +11,7 @@ Each document covers: purpose, public API, implementation constraints, and test 
 | [spec-snapshot](spec-snapshot.md)     | `snapshot` (feature-gated)                   |
 | [spec-live](spec-live.md)             | `live::GraphState<G>` (feature-gated)        |
 | [spec-snapshot-lz4](spec-snapshot-lz4.md) | `snapshot-lz4` compression sub-feature  |
+| [spec-snapshot-lazy-meta](spec-snapshot-lazy-meta.md) | `inspect`/`list` without loading graph body |
 
 ## Feature flags
 

--- a/docs/specifications/spec-snapshot-lazy-meta.md
+++ b/docs/specifications/spec-snapshot-lazy-meta.md
@@ -13,7 +13,7 @@ last_updated: "2026-05-02"
 
 **Crate:** `petgraph-live`
 **Feature flag:** `snapshot` (no new feature — improvement to existing functions)
-**Status:** pre-implementation
+**Status:** implemented
 **Depends on:** `snapshot` module (implemented)
 
 ---

--- a/examples/snapshot_compression.rs
+++ b/examples/snapshot_compression.rs
@@ -1,0 +1,76 @@
+/// Demonstrates all three `Compression` variants: None, Zstd, and Lz4.
+///
+/// Run with:
+///   cargo run --example snapshot_compression --features snapshot-zstd,snapshot-lz4
+use petgraph::Graph;
+use petgraph_live::snapshot::{Compression, SnapshotConfig, SnapshotFormat, inspect, load, save};
+
+fn make_graph() -> Graph<String, String> {
+    let mut g: Graph<String, String> = Graph::new();
+    let a = g.add_node("Paris".into());
+    let b = g.add_node("London".into());
+    let c = g.add_node("Berlin".into());
+    g.add_edge(a, b, "eurostar".into());
+    g.add_edge(b, c, "flight".into());
+    g
+}
+
+fn roundtrip(dir: &std::path::Path, label: &str, compression: Compression, ext: &str) {
+    let cfg = SnapshotConfig {
+        dir: dir.to_path_buf(),
+        name: label.into(),
+        key: Some("v1".into()),
+        format: SnapshotFormat::Bincode,
+        compression,
+        keep: 5,
+    };
+
+    let graph = make_graph();
+    save(&cfg, &graph).expect("save");
+
+    // Verify the file extension matches the compression variant
+    let path = dir.join(format!("{}-v1{}", label, ext));
+    assert!(path.exists(), "expected file: {}", path.display());
+    println!("  saved → {}", path.file_name().unwrap().to_string_lossy());
+
+    // inspect: metadata only — graph bytes never deserialized
+    let meta = inspect(&cfg).expect("inspect").expect("meta present");
+    assert_eq!(meta.node_count, 3);
+    assert_eq!(meta.compression, cfg.compression.clone());
+    println!(
+        "  inspect → nodes={}, compression={:?}",
+        meta.node_count, meta.compression
+    );
+
+    // load: full roundtrip
+    let loaded: Graph<String, String> = load(&cfg).expect("load").expect("present");
+    assert_eq!(loaded.node_count(), graph.node_count());
+    assert_eq!(loaded.edge_count(), graph.edge_count());
+    println!("  load   → nodes={} ✓", loaded.node_count());
+}
+
+fn main() {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    println!("--- Compression::None (bincode, .snap) ---");
+    roundtrip(dir.path(), "none", Compression::None, ".snap");
+
+    #[cfg(feature = "snapshot-zstd")]
+    {
+        println!("--- Compression::Zstd {{ level: 3 }} (.snap.zst) ---");
+        roundtrip(
+            dir.path(),
+            "zstd",
+            Compression::Zstd { level: 3 },
+            ".snap.zst",
+        );
+    }
+
+    #[cfg(feature = "snapshot-lz4")]
+    {
+        println!("--- Compression::Lz4 (.snap.lz4) ---");
+        roundtrip(dir.path(), "lz4", Compression::Lz4, ".snap.lz4");
+    }
+
+    println!("snapshot_compression: all assertions passed");
+}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -27,6 +27,7 @@ pub struct GenerationCache<G> {
 }
 
 impl<G> GenerationCache<G> {
+    /// Create an empty cache with no cached graph.
     pub fn new() -> Self {
         GenerationCache {
             inner: RwLock::new(None),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,28 @@
 //! `petgraph-live` — graph cache, snapshot, and algorithms for petgraph 0.8.
 //!
-//! **Status: coming soon.** Implementation in progress.
+//! # Features
 //!
-//! See [README](https://github.com/geronimo-iia/petgraph-live) for the roadmap.
+//! | Feature | Description |
+//! |---|---|
+//! | *(default)* | [`cache`], [`metrics`], [`connect`], [`shortest_path`], [`mst`] |
+//! | `snapshot` | Disk persistence via bincode or JSON |
+//! | `snapshot-zstd` | Zstd compression for snapshots (implies `snapshot`) |
+//! | `snapshot-lz4` | LZ4 compression via `lz4_flex` (implies `snapshot`) |
+//!
+//! Enabling `snapshot` also gates [`live`], which composes the cache with snapshot lifecycle.
+//!
+//! # Quick start
+//!
+//! ```rust
+//! use petgraph_live::cache::GenerationCache;
+//! use std::sync::Arc;
+//!
+//! let cache: GenerationCache<Vec<u32>> = GenerationCache::new();
+//! let g: Arc<Vec<u32>> = cache.get_or_build(1, || Ok::<_, ()>(vec![1, 2, 3])).unwrap();
+//! assert_eq!(*g, vec![1, 2, 3]);
+//! ```
+//!
+//! See [README](https://github.com/geronimo-iia/petgraph-live) for more examples.
 
 pub mod cache;
 pub mod connect;

--- a/src/snapshot/io.rs
+++ b/src/snapshot/io.rs
@@ -380,8 +380,11 @@ where
 
 /// Read snapshot metadata without deserializing the graph.
 ///
-/// For bincode files only the length-prefixed header bytes are parsed.
-/// For JSON files only the `"meta"` field is extracted.
+/// For uncompressed bincode, reads only the metadata header — graph bytes are never
+/// loaded from disk. For compressed files the full file is decompressed first, but
+/// graph deserialization is still skipped. For JSON files only the `"meta"` field is
+/// extracted; `G::deserialize` is never called.
+///
 /// Returns `Ok(None)` when no matching file exists.
 ///
 /// # Examples
@@ -417,7 +420,9 @@ pub fn inspect(cfg: &SnapshotConfig) -> Result<Option<SnapshotMeta>, SnapshotErr
 
 /// Return all snapshots in `cfg.dir` matching `cfg.name`, ordered oldest first by mtime.
 ///
-/// Each entry is `(path, meta)`. The key is `None` in `cfg` for listing all files.
+/// Each entry is `(path, meta)`. Set `cfg.key = None` to list all files.
+/// For uncompressed bincode files, reads only the metadata header — graph bytes are
+/// never loaded from disk. For JSON files, `G::deserialize` is never called.
 ///
 /// # Examples
 ///

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -1,11 +1,15 @@
 //! Serde-based disk persistence for petgraph graphs.
 //!
-//! Enabled with the `snapshot` feature flag. Optional zstd compression requires
-//! `snapshot-zstd`.
+//! Enabled with the `snapshot` feature flag. Optional compression:
+//! - `snapshot-zstd` — Zstd compression
+//! - `snapshot-lz4` — LZ4 compression via `lz4_flex` (pure Rust)
 //!
 //! Snapshots are stored as `{name}-{sanitized_key}.{ext}` files. The key is
 //! encoded in the filename so two saves with the same key overwrite each other.
 //! Rotation keeps the latest `keep` files by filesystem mtime.
+//!
+//! [`inspect`] and [`list`] use partial reads for uncompressed bincode files —
+//! only the `8 + meta_len` byte header is read from disk; graph bytes are never loaded.
 //!
 //! # Quick start
 //!


### PR DESCRIPTION
Release preparation for v0.3.0. Closes #5.

## Changes
- `snapshot-lz4` feature: LZ4 compression via `lz4_flex` (pure Rust)
- `inspect()`/`list()` lazy metadata: partial bincode read, MetaOnly JSON serde

## Commits
- chore: bump version to 0.3.0
- docs(rustdoc): audit and update public item docs for v0.3.0
- docs(changelog): add v0.3.0 section
- docs(readme): update to v0.3.0
- docs(release): update v0.3.0 — add lz4 test matrix, remove manual publish
- docs(security): update supported versions to 0.3.x
- docs(api-design): update version target and lazy metadata notes
- docs(specs): mark v0.3.0 features implemented