### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `hebbian` module — SOKM (Self-Organizing Knowledge Map) algorithm: `decay`, `strengthen`, `prune`, `sokm_tick`; works on both directed and undirected `StableGraph<N, f64, Ty>`; config types `SokmConfig`, `StrengthFormula`, `HebbianReport`; example `hebbian_sokm`; criterion benchmark
 - `hebbian::stdp_update` — Spike-Timing Dependent Plasticity: causal pairs strengthened, anti-causal weakened, with exponential time decay
 - `hebbian::anti_hebbian_update` — lateral inhibition: weakens edges between co-activated nodes (competitive learning)
+- `hebbian::oja_update` — Oja's normalized Hebbian rule: self-converging weights toward principal component
+- `hebbian::bcm_update` — BCM homeostatic plasticity: sliding threshold prevents runaway strengthening
 
 ## [0.3.1] — 2026-05-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.0] — 2026-06-29
 
 ### Added
 - `hebbian` module — SOKM (Self-Organizing Knowledge Map) algorithm: `decay`, `strengthen`, `prune`, `sokm_tick`; works on both directed and undirected `StableGraph<N, f64, Ty>`; config types `SokmConfig`, `StrengthFormula`, `HebbianReport`; example `hebbian_sokm`; criterion benchmark
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `hebbian::anti_hebbian_update` — lateral inhibition: weakens edges between co-activated nodes (competitive learning)
 - `hebbian::oja_update` — Oja's normalized Hebbian rule: self-converging weights toward principal component
 - `hebbian::bcm_update` — BCM homeostatic plasticity: sliding threshold prevents runaway strengthening
+
+## [Unreleased]
 
 ## [0.3.1] — 2026-05-03
 
@@ -54,5 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SECURITY.md`, `docs/release.md`, `docs/specifications/` index,
   `docs/roadmap.md`, `docs/api-design.md`
 
+[0.4.0]: https://github.com/geronimo-iia/petgraph-live/compare/v0.3.1...v0.4.0
+[0.3.1]: https://github.com/geronimo-iia/petgraph-live/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/geronimo-iia/petgraph-live/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/geronimo-iia/petgraph-live/releases/tag/v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `hebbian` module — SOKM (Self-Organizing Knowledge Map) algorithm: `decay`, `strengthen`, `prune`, `sokm_tick`; works on both directed and undirected `StableGraph<N, f64, Ty>`; config types `SokmConfig`, `StrengthFormula`, `HebbianReport`; example `hebbian_sokm`; criterion benchmark
+
 ## [0.3.1] — 2026-05-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `hebbian` module — SOKM (Self-Organizing Knowledge Map) algorithm: `decay`, `strengthen`, `prune`, `sokm_tick`; works on both directed and undirected `StableGraph<N, f64, Ty>`; config types `SokmConfig`, `StrengthFormula`, `HebbianReport`; example `hebbian_sokm`; criterion benchmark
+- `hebbian::stdp_update` — Spike-Timing Dependent Plasticity: causal pairs strengthened, anti-causal weakened, with exponential time decay
+- `hebbian::anti_hebbian_update` — lateral inhibition: weakens edges between co-activated nodes (competitive learning)
 
 ## [0.3.1] — 2026-05-03
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "petgraph-live"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "bincode",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,37 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bincode"
@@ -35,6 +62,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,6 +90,131 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "equivalent"
@@ -103,6 +267,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +316,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +348,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,6 +372,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +405,17 @@ checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
  "getrandom 0.3.4",
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -222,10 +458,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "petgraph"
@@ -245,6 +496,7 @@ name = "petgraph-live"
 version = "0.3.1"
 dependencies = [
  "bincode",
+ "criterion",
  "filetime",
  "lz4_flex",
  "petgraph",
@@ -256,10 +508,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "prettyplease"
@@ -302,6 +588,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,6 +647,21 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -370,6 +720,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,6 +770,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +810,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,6 +835,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -493,6 +914,25 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -602,6 +1042,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "petgraph-live"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.95"
 description = "Generic generation-keyed graph cache, disk snapshot, and graph algorithms for petgraph 0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,11 @@ lz4_flex   = { version = "0.13", optional = true }
 [dev-dependencies]
 tempfile = "3"
 filetime = "0.2"
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "hebbian"
+harness = false
 
 [[example]]
 name = "snapshot_basic"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ the operational layer missing for long-running processes:
   - `connect`: articulation points, bridges
   - `shortest_path`: Floyd-Warshall, Seidel APSP, BFS distances, petgraph re-exports
   - `mst`: Prim, Borůvka, Kruskal (petgraph re-export)
+  - `hebbian`: SOKM, STDP, anti-Hebbian, Oja, BCM — dynamic edge-weight learning
 
 All algorithms work on any `DiGraph<N, E>` — no domain concepts inside this crate.
 
@@ -47,6 +48,21 @@ let c = metrics::center(&graph);     // most central nodes
 // Connectivity analysis
 let ap = connect::articulation_points(&graph);
 let br = connect::find_bridges(&graph);
+```
+
+Hebbian learning (dynamic edge weights):
+
+```rust
+use petgraph::stable_graph::StableDiGraph;
+use petgraph_live::hebbian::{sokm_tick, SokmConfig};
+
+let mut graph = StableDiGraph::<&str, f64>::new();
+let a = graph.add_node("A");
+let b = graph.add_node("B");
+graph.add_edge(a, b, 0.5);
+
+// One SOKM tick: decay → strengthen → prune
+let report = sokm_tick(&mut graph, &[(a, 1.0), (b, 0.8)], &SokmConfig::default());
 ```
 
 With snapshot (requires `features = ["snapshot"]`):
@@ -81,7 +97,7 @@ let graph = state.get_fresh()?;     // checks key, rebuilds if stale
 
 | Flag | Adds |
 |---|---|
-| _(default)_ | `cache`, `metrics`, `connect`, `shortest_path`, `mst` |
+| _(default)_ | `cache`, `metrics`, `connect`, `shortest_path`, `mst`, `hebbian` |
 | `snapshot` | `snapshot`, `live` |
 | `snapshot-zstd` | zstd compression for snapshots (implies `snapshot`) |
 | `snapshot-lz4` | LZ4 compression for snapshots via `lz4_flex` (implies `snapshot`) |

--- a/benches/hebbian.rs
+++ b/benches/hebbian.rs
@@ -1,0 +1,51 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use petgraph::stable_graph::StableDiGraph;
+use petgraph_live::hebbian::{SokmConfig, decay, prune, sokm_tick, strengthen};
+
+fn build_graph(n: usize) -> StableDiGraph<(), f64> {
+    let mut g = StableDiGraph::new();
+    let nodes: Vec<_> = (0..n).map(|_| g.add_node(())).collect();
+    // Create a dense-ish graph: each node connects to next 5
+    for i in 0..n {
+        for j in 1..=5 {
+            let target = (i + j) % n;
+            g.add_edge(nodes[i], nodes[target], 0.5);
+        }
+    }
+    g
+}
+
+fn bench_decay(c: &mut Criterion) {
+    let mut g = build_graph(1000);
+    c.bench_function("decay_1000_nodes", |b| {
+        b.iter(|| decay(&mut g, 0.95));
+    });
+}
+
+fn bench_strengthen(c: &mut Criterion) {
+    let mut g = build_graph(1000);
+    let nodes: Vec<_> = g.node_indices().take(20).map(|n| (n, 0.8)).collect();
+    let config = SokmConfig::default();
+    c.bench_function("strengthen_20_activated_1000_nodes", |b| {
+        b.iter(|| strengthen(&mut g, &nodes, &config));
+    });
+}
+
+fn bench_prune(c: &mut Criterion) {
+    let mut g = build_graph(1000);
+    c.bench_function("prune_1000_nodes", |b| {
+        b.iter(|| prune(&mut g, 0.001));
+    });
+}
+
+fn bench_sokm_tick(c: &mut Criterion) {
+    let mut g = build_graph(1000);
+    let nodes: Vec<_> = g.node_indices().take(20).map(|n| (n, 0.8)).collect();
+    let config = SokmConfig::default();
+    c.bench_function("sokm_tick_20_activated_1000_nodes", |b| {
+        b.iter(|| sokm_tick(&mut g, &nodes, &config));
+    });
+}
+
+criterion_group!(benches, bench_decay, bench_strengthen, bench_prune, bench_sokm_tick);
+criterion_main!(benches);

--- a/benches/hebbian.rs
+++ b/benches/hebbian.rs
@@ -20,7 +20,14 @@ fn build_graph(n: usize) -> StableDiGraph<(), f64> {
 
 fn bench_decay(c: &mut Criterion) {
     let mut g = build_graph(1000);
-    c.bench_function("decay_1000_nodes", |b| {
+    c.bench_function("decay_5k_edges", |b| {
+        b.iter(|| decay(&mut g, 0.95));
+    });
+}
+
+fn bench_decay_100k(c: &mut Criterion) {
+    let mut g = build_graph(20_000); // 20K nodes × 5 = 100K edges
+    c.bench_function("decay_100k_edges", |b| {
         b.iter(|| decay(&mut g, 0.95));
     });
 }
@@ -29,7 +36,16 @@ fn bench_strengthen(c: &mut Criterion) {
     let mut g = build_graph(1000);
     let nodes: Vec<_> = g.node_indices().take(20).map(|n| (n, 0.8)).collect();
     let config = SokmConfig::default();
-    c.bench_function("strengthen_20_activated_1000_nodes", |b| {
+    c.bench_function("strengthen_20_activated_5k_edges", |b| {
+        b.iter(|| strengthen(&mut g, &nodes, &config));
+    });
+}
+
+fn bench_strengthen_10(c: &mut Criterion) {
+    let mut g = build_graph(1000);
+    let nodes: Vec<_> = g.node_indices().take(10).map(|n| (n, 0.8)).collect();
+    let config = SokmConfig::default();
+    c.bench_function("strengthen_10_activated_5k_edges", |b| {
         b.iter(|| strengthen(&mut g, &nodes, &config));
     });
 }
@@ -76,7 +92,9 @@ fn bench_anti_hebbian(c: &mut Criterion) {
 criterion_group!(
     benches,
     bench_decay,
+    bench_decay_100k,
     bench_strengthen,
+    bench_strengthen_10,
     bench_prune,
     bench_sokm_tick,
     bench_stdp,

--- a/benches/hebbian.rs
+++ b/benches/hebbian.rs
@@ -1,8 +1,8 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use petgraph::stable_graph::StableDiGraph;
 use petgraph_live::hebbian::{
-    AntiHebbianConfig, BcmConfig, BcmState, OjaConfig, SokmConfig, StdpConfig,
-    anti_hebbian_update, bcm_update, decay, oja_update, prune, sokm_tick, stdp_update, strengthen,
+    AntiHebbianConfig, BcmConfig, BcmState, OjaConfig, SokmConfig, StdpConfig, anti_hebbian_update,
+    bcm_update, decay, oja_update, prune, sokm_tick, stdp_update, strengthen,
 };
 
 fn build_graph(n: usize) -> StableDiGraph<(), f64> {
@@ -92,7 +92,12 @@ fn bench_anti_hebbian(c: &mut Criterion) {
 fn bench_oja(c: &mut Criterion) {
     let mut g = build_graph(1000);
     let pre: Vec<_> = g.node_indices().take(10).map(|n| (n, 0.8)).collect();
-    let post: Vec<_> = g.node_indices().skip(5).take(10).map(|n| (n, 0.7)).collect();
+    let post: Vec<_> = g
+        .node_indices()
+        .skip(5)
+        .take(10)
+        .map(|n| (n, 0.7))
+        .collect();
     let config = OjaConfig::default();
     c.bench_function("oja_10x10_activated_5k_edges", |b| {
         b.iter(|| oja_update(&mut g, &pre, &post, &config));

--- a/benches/hebbian.rs
+++ b/benches/hebbian.rs
@@ -1,6 +1,9 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use petgraph::stable_graph::StableDiGraph;
-use petgraph_live::hebbian::{SokmConfig, decay, prune, sokm_tick, strengthen};
+use petgraph_live::hebbian::{
+    AntiHebbianConfig, SokmConfig, StdpConfig, anti_hebbian_update, decay, prune, sokm_tick,
+    stdp_update, strengthen,
+};
 
 fn build_graph(n: usize) -> StableDiGraph<(), f64> {
     let mut g = StableDiGraph::new();
@@ -47,5 +50,36 @@ fn bench_sokm_tick(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_decay, bench_strengthen, bench_prune, bench_sokm_tick);
+fn bench_stdp(c: &mut Criterion) {
+    let mut g = build_graph(1000);
+    let activations: Vec<_> = g
+        .node_indices()
+        .take(20)
+        .enumerate()
+        .map(|(i, n)| (n, 0.8, i as u64))
+        .collect();
+    let config = StdpConfig::default();
+    c.bench_function("stdp_20_activated_1000_nodes", |b| {
+        b.iter(|| stdp_update(&mut g, &activations, &config));
+    });
+}
+
+fn bench_anti_hebbian(c: &mut Criterion) {
+    let mut g = build_graph(1000);
+    let nodes: Vec<_> = g.node_indices().take(20).map(|n| (n, 0.8)).collect();
+    let config = AntiHebbianConfig::default();
+    c.bench_function("anti_hebbian_20_activated_1000_nodes", |b| {
+        b.iter(|| anti_hebbian_update(&mut g, &nodes, &config));
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_decay,
+    bench_strengthen,
+    bench_prune,
+    bench_sokm_tick,
+    bench_stdp,
+    bench_anti_hebbian
+);
 criterion_main!(benches);

--- a/benches/hebbian.rs
+++ b/benches/hebbian.rs
@@ -1,8 +1,8 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use petgraph::stable_graph::StableDiGraph;
 use petgraph_live::hebbian::{
-    AntiHebbianConfig, SokmConfig, StdpConfig, anti_hebbian_update, decay, prune, sokm_tick,
-    stdp_update, strengthen,
+    AntiHebbianConfig, BcmConfig, BcmState, OjaConfig, SokmConfig, StdpConfig,
+    anti_hebbian_update, bcm_update, decay, oja_update, prune, sokm_tick, stdp_update, strengthen,
 };
 
 fn build_graph(n: usize) -> StableDiGraph<(), f64> {
@@ -84,8 +84,28 @@ fn bench_anti_hebbian(c: &mut Criterion) {
     let mut g = build_graph(1000);
     let nodes: Vec<_> = g.node_indices().take(20).map(|n| (n, 0.8)).collect();
     let config = AntiHebbianConfig::default();
-    c.bench_function("anti_hebbian_20_activated_1000_nodes", |b| {
+    c.bench_function("anti_hebbian_20_activated_5k_edges", |b| {
         b.iter(|| anti_hebbian_update(&mut g, &nodes, &config));
+    });
+}
+
+fn bench_oja(c: &mut Criterion) {
+    let mut g = build_graph(1000);
+    let pre: Vec<_> = g.node_indices().take(10).map(|n| (n, 0.8)).collect();
+    let post: Vec<_> = g.node_indices().skip(5).take(10).map(|n| (n, 0.7)).collect();
+    let config = OjaConfig::default();
+    c.bench_function("oja_10x10_activated_5k_edges", |b| {
+        b.iter(|| oja_update(&mut g, &pre, &post, &config));
+    });
+}
+
+fn bench_bcm(c: &mut Criterion) {
+    let mut g = build_graph(1000);
+    let nodes: Vec<_> = g.node_indices().take(20).map(|n| (n, 0.8)).collect();
+    let mut state = BcmState::new(1000, 0.5);
+    let config = BcmConfig::default();
+    c.bench_function("bcm_20_activated_5k_edges", |b| {
+        b.iter(|| bcm_update(&mut g, &nodes, &mut state, &config));
     });
 }
 
@@ -98,6 +118,8 @@ criterion_group!(
     bench_prune,
     bench_sokm_tick,
     bench_stdp,
-    bench_anti_hebbian
+    bench_anti_hebbian,
+    bench_oja,
+    bench_bcm
 );
 criterion_main!(benches);

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -11,6 +11,7 @@ petgraph_live
 ├── connect        Articulation points, bridges
 ├── shortest_path  Floyd-Warshall, Seidel, BFS distances, petgraph re-exports
 ├── mst            Prim, Borůvka (Kruskal re-exported from petgraph)
+├── hebbian        Dynamic edge-weight learning (SOKM, STDP, anti-Hebbian, Oja, BCM)
 ├── snapshot       Serde-based disk persistence (feature "snapshot")
 └── live           GraphState<G> — composes cache + snapshot (feature "snapshot")
 ```
@@ -106,6 +107,60 @@ use petgraph_live::mst;
 mst::prim(&graph, |e| *e.weight())    // Vec<(G::NodeId, G::NodeId)>
 mst::boruvka(&graph, |e| *e.weight()) // Vec<(G::NodeId, G::NodeId)>
 mst::kruskal(&graph)                  // impl Iterator<Item = Element<N,E>> — petgraph re-export
+```
+
+## Module: `hebbian`
+
+Dynamic edge-weight learning. All functions operate on `StableGraph<N, f64, Ty>`
+where `Ty: EdgeType` (directed or undirected). No extra dependencies.
+
+### SOKM (Self-Organizing Knowledge Map)
+
+```rust
+use petgraph_live::hebbian::{sokm_tick, decay, strengthen, prune, SokmConfig};
+
+// Full tick: decay → strengthen → prune
+let report = sokm_tick(&mut graph, &[(node_a, 1.0), (node_b, 0.8)], &SokmConfig::default());
+
+// Individual phases
+let n = decay(&mut graph, 0.95);
+let n = strengthen(&mut graph, &activated, &config);
+let n = prune(&mut graph, 0.001);
+```
+
+### STDP (Spike-Timing Dependent Plasticity)
+
+```rust
+use petgraph_live::hebbian::{stdp_update, StdpConfig};
+
+// Timed activations: (node, score, tick_fired)
+let activations = vec![(a, 1.0, 1), (b, 0.9, 3)];
+stdp_update(&mut graph, &activations, &StdpConfig::default());
+```
+
+### Anti-Hebbian (lateral inhibition)
+
+```rust
+use petgraph_live::hebbian::{anti_hebbian_update, AntiHebbianConfig};
+
+anti_hebbian_update(&mut graph, &activated, &AntiHebbianConfig::default());
+```
+
+### Oja (normalized Hebbian)
+
+```rust
+use petgraph_live::hebbian::{oja_update, OjaConfig};
+
+oja_update(&mut graph, &pre_activations, &post_activations, &OjaConfig::default());
+```
+
+### BCM (homeostatic plasticity)
+
+```rust
+use petgraph_live::hebbian::{bcm_update, BcmConfig, BcmState};
+
+let mut state = BcmState::new(node_count, 0.5);
+bcm_update(&mut graph, &activated, &mut state, &BcmConfig::default());
 ```
 
 ## Module: `snapshot` (feature-gated)
@@ -255,6 +310,7 @@ Two concurrent `get_fresh()` callers detecting a stale key both call `build_fn`
 | ------------------ | ----------------------------------------------- |
 | `cache`            | caller-supplied `E` from the `build` closure    |
 | `metrics`          | no `Result` — `None` for degenerate/empty cases |
+| `hebbian`          | no `Result` — returns counts/reports            |
 | `shortest_path`    | `NegativeCycle` (petgraph re-export)            |
 | `snapshot`, `live` | `SnapshotError`                                 |
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,7 +8,7 @@ Extended algorithms
 
 | Feature                                              | Notes                                                    |
 | ---------------------------------------------------- | -------------------------------------------------------- |
-| `hebbian` — Oja, BCM variants                        | Phase 3 of Hebbian module (SOKM, STDP, Anti-Hebbian done) |
+| `hebbian` — additional variants                      | Future extensions beyond SOKM/STDP/Anti-Hebbian/Oja/BCM |
 | `elementary_circuits` — Tarjan's circuit enumeration | Needs careful cycle detection, expensive on dense graphs |
 | `tournament` module                                  | Tournament-specific algorithms from graphalgs            |
 | `coloring::dsatur`                                   | DSATUR greedy graph colouring                            |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,7 +8,6 @@ Extended algorithms
 
 | Feature                                              | Notes                                                    |
 | ---------------------------------------------------- | -------------------------------------------------------- |
-| `hebbian` — additional variants                      | Future extensions beyond SOKM/STDP/Anti-Hebbian/Oja/BCM |
 | `elementary_circuits` — Tarjan's circuit enumeration | Needs careful cycle detection, expensive on dense graphs |
 | `tournament` module                                  | Tournament-specific algorithms from graphalgs            |
 | `coloring::dsatur`                                   | DSATUR greedy graph colouring                            |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,6 +8,7 @@ Extended algorithms
 
 | Feature                                              | Notes                                                    |
 | ---------------------------------------------------- | -------------------------------------------------------- |
+| `hebbian` — STDP, Oja, anti-Hebbian, BCM variants   | Phase 2+ of Hebbian module (SOKM done in v0.4)          |
 | `elementary_circuits` — Tarjan's circuit enumeration | Needs careful cycle detection, expensive on dense graphs |
 | `tournament` module                                  | Tournament-specific algorithms from graphalgs            |
 | `coloring::dsatur`                                   | DSATUR greedy graph colouring                            |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,7 +8,7 @@ Extended algorithms
 
 | Feature                                              | Notes                                                    |
 | ---------------------------------------------------- | -------------------------------------------------------- |
-| `hebbian` — STDP, Oja, anti-Hebbian, BCM variants   | Phase 2+ of Hebbian module (SOKM done in v0.4)          |
+| `hebbian` — Oja, BCM variants                        | Phase 3 of Hebbian module (SOKM, STDP, Anti-Hebbian done) |
 | `elementary_circuits` — Tarjan's circuit enumeration | Needs careful cycle detection, expensive on dense graphs |
 | `tournament` module                                  | Tournament-specific algorithms from graphalgs            |
 | `coloring::dsatur`                                   | DSATUR greedy graph colouring                            |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # petgraph-live — Roadmap
 
-**Current status:** v0.3.0 released.
+**Current status:** v0.4.0 released.
 
 ## Futur improvments
 

--- a/docs/specifications/spec-algorithms.md
+++ b/docs/specifications/spec-algorithms.md
@@ -98,6 +98,54 @@ pub use petgraph::algo::{
 `seidel`: unweighted APSP for undirected graphs (Seidel/APD algorithm),
 O(n^ω log n). No nalgebra — matrix operations over `Vec<Vec<u32>>`.
 
+## Module: `hebbian`
+
+Dynamic graph learning — Hebbian algorithms that modify edge weights based on
+node co-activation patterns. Pure computation, zero additional dependencies.
+
+Operates on `StableGraph<N, f64, Ty>` where `Ty: EdgeType` (both directed and
+undirected). Requires `StableGraph` because `prune` removes edges during
+iteration.
+
+### Design principles
+
+- Free functions (same style as `metrics`, `connect`)
+- Config as plain `#[derive(Debug, Clone, Copy)]` structs with `Default`
+- Operations return counts/diagnostics (`HebbianReport`), not `Result`
+- For undirected graphs, `strengthen` processes each unordered pair once
+
+### Public API
+
+```rust
+/// Configuration for SOKM dynamics.
+pub struct SokmConfig {
+    pub decay_factor: f64,    // default: 0.95
+    pub delta: f64,           // default: 0.02
+    pub min_weight: f64,      // default: 0.001
+    pub formula: StrengthFormula,
+}
+
+pub enum StrengthFormula { Product, Min, Average }
+
+pub struct HebbianReport {
+    pub decayed: usize,
+    pub strengthened: usize,
+    pub pruned: usize,
+}
+
+pub fn decay<N, Ty: EdgeType>(graph: &mut StableGraph<N, f64, Ty>, factor: f64) -> usize
+pub fn strengthen<N, Ty: EdgeType>(graph: &mut StableGraph<N, f64, Ty>, activated: &[(NodeIndex, f64)], config: &SokmConfig) -> usize
+pub fn prune<N, Ty: EdgeType>(graph: &mut StableGraph<N, f64, Ty>, threshold: f64) -> usize
+pub fn sokm_tick<N, Ty: EdgeType>(graph: &mut StableGraph<N, f64, Ty>, activated: &[(NodeIndex, f64)], config: &SokmConfig) -> HebbianReport
+```
+
+### SOKM algorithm
+
+Each tick executes three phases in order:
+1. **Decay** — multiply all edge weights by `decay_factor`
+2. **Strengthen** — for each co-activated pair, increment edge weight by formula
+3. **Prune** — remove edges with weight below `min_weight`
+
 ## Module: `mst`
 
 ### Deviations from graphalgs

--- a/docs/specifications/spec-algorithms.md
+++ b/docs/specifications/spec-algorithms.md
@@ -179,6 +179,35 @@ pub struct AntiHebbianConfig {
 pub fn anti_hebbian_update<N, Ty: EdgeType>(graph: &mut StableGraph<N, f64, Ty>, activated: &[(NodeIndex, f64)], config: &AntiHebbianConfig) -> usize
 ```
 
+### Oja's rule
+
+Normalized Hebbian. Weights self-converge without manual capping.
+Δw = η × y × (x − w × y)
+
+```rust
+pub struct OjaConfig {
+    pub learning_rate: f64,  // default: 0.01
+}
+
+pub fn oja_update<N, Ty: EdgeType>(graph: &mut StableGraph<N, f64, Ty>, pre_activations: &[(NodeIndex, f64)], post_activations: &[(NodeIndex, f64)], config: &OjaConfig) -> usize
+```
+
+### BCM rule
+
+Homeostatic plasticity with per-node sliding threshold. Prevents runaway
+strengthening.
+
+```rust
+pub struct BcmConfig {
+    pub learning_rate: f64,   // default: 0.01
+    pub threshold_rate: f64,  // default: 0.001
+}
+
+pub struct BcmState { pub thresholds: Vec<f64> }
+
+pub fn bcm_update<N, Ty: EdgeType>(graph: &mut StableGraph<N, f64, Ty>, activated: &[(NodeIndex, f64)], state: &mut BcmState, config: &BcmConfig) -> usize
+```
+
 ## Module: `mst`
 
 ### Deviations from graphalgs

--- a/docs/specifications/spec-algorithms.md
+++ b/docs/specifications/spec-algorithms.md
@@ -146,6 +146,39 @@ Each tick executes three phases in order:
 2. **Strengthen** — for each co-activated pair, increment edge weight by formula
 3. **Prune** — remove edges with weight below `min_weight`
 
+### STDP algorithm
+
+Spiking-Timing Dependent Plasticity. For each directed edge (pre → post)
+where both endpoints fired:
+- Causal (pre fires before post): Δw = +a_plus × exp(-Δt / tau_plus)
+- Anti-causal (post fires before pre): Δw = -a_minus × exp(-Δt / tau_minus)
+
+```rust
+pub struct StdpConfig {
+    pub a_plus: f64,     // default: 0.01
+    pub a_minus: f64,    // default: 0.005
+    pub tau_plus: f64,   // default: 5.0
+    pub tau_minus: f64,  // default: 5.0
+}
+
+pub type TimedActivation = (NodeIndex, f64, u64);
+
+pub fn stdp_update<N, Ty: EdgeType>(graph: &mut StableGraph<N, f64, Ty>, activations: &[TimedActivation], config: &StdpConfig) -> usize
+```
+
+### Anti-Hebbian algorithm
+
+Lateral inhibition — weakens edges between co-activated nodes. Opposite of
+SOKM strengthen. Forces specialization.
+
+```rust
+pub struct AntiHebbianConfig {
+    pub beta: f64,  // default: 0.005
+}
+
+pub fn anti_hebbian_update<N, Ty: EdgeType>(graph: &mut StableGraph<N, f64, Ty>, activated: &[(NodeIndex, f64)], config: &AntiHebbianConfig) -> usize
+```
+
 ## Module: `mst`
 
 ### Deviations from graphalgs

--- a/examples/hebbian_anti.rs
+++ b/examples/hebbian_anti.rs
@@ -1,0 +1,42 @@
+use petgraph::stable_graph::StableDiGraph;
+use petgraph_live::hebbian::{AntiHebbianConfig, anti_hebbian_update, prune};
+
+fn main() {
+    let mut graph = StableDiGraph::<&str, f64>::new();
+    let cat = graph.add_node("cat");
+    let dog = graph.add_node("dog");
+    let pet = graph.add_node("pet");
+
+    // Both cat and dog connect to "pet" — they compete for specialization
+    graph.add_edge(cat, pet, 0.5);
+    graph.add_edge(dog, pet, 0.5);
+    graph.add_edge(cat, dog, 0.3);
+    graph.add_edge(dog, cat, 0.3);
+
+    let config = AntiHebbianConfig { beta: 0.05 };
+
+    println!("--- Initial graph ---");
+    print_edges(&graph);
+
+    // cat and dog co-activate repeatedly — lateral inhibition weakens their link
+    for tick in 1..=10 {
+        let weakened = anti_hebbian_update(&mut graph, &[(cat, 1.0), (dog, 0.9)], &config);
+        if tick % 5 == 0 {
+            println!("\n--- After tick {tick} (cat + dog co-active, {weakened} weakened) ---");
+            print_edges(&graph);
+        }
+    }
+
+    // Prune dead connections
+    let pruned = prune(&mut graph, 0.01);
+    println!("\n--- After prune (removed {pruned} edges) ---");
+    print_edges(&graph);
+}
+
+fn print_edges(graph: &StableDiGraph<&str, f64>) {
+    for idx in graph.edge_indices() {
+        let (src, dst) = graph.edge_endpoints(idx).unwrap();
+        let w = graph.edge_weight(idx).unwrap();
+        println!("  {} -> {} : {:.6}", graph[src], graph[dst], w);
+    }
+}

--- a/examples/hebbian_bcm.rs
+++ b/examples/hebbian_bcm.rs
@@ -1,0 +1,54 @@
+use petgraph::stable_graph::StableDiGraph;
+use petgraph_live::hebbian::{BcmConfig, BcmState, bcm_update};
+
+fn main() {
+    let mut graph = StableDiGraph::<&str, f64>::new();
+    let input = graph.add_node("input");
+    let neuron_a = graph.add_node("neuron_a");
+    let neuron_b = graph.add_node("neuron_b");
+
+    graph.add_edge(input, neuron_a, 0.5);
+    graph.add_edge(input, neuron_b, 0.5);
+
+    let config = BcmConfig {
+        learning_rate: 0.05,
+        threshold_rate: 0.1,
+    };
+    let mut state = BcmState::new(3, 0.5);
+
+    println!("--- BCM: homeostatic plasticity ---");
+    println!("Initial (threshold=0.5 for all):");
+    print_state(&graph, &state);
+
+    // neuron_a is highly active → threshold rises → harder to strengthen
+    for epoch in 1..=20 {
+        bcm_update(
+            &mut graph,
+            &[(input, 0.9), (neuron_a, 0.95)],
+            &mut state,
+            &config,
+        );
+        // neuron_b gets low activation → threshold drops → easier to strengthen
+        bcm_update(
+            &mut graph,
+            &[(input, 0.9), (neuron_b, 0.3)],
+            &mut state,
+            &config,
+        );
+        if epoch % 5 == 0 {
+            println!("\nAfter epoch {epoch}:");
+            print_state(&graph, &state);
+        }
+    }
+}
+
+fn print_state(graph: &StableDiGraph<&str, f64>, state: &BcmState) {
+    for idx in graph.edge_indices() {
+        let (src, dst) = graph.edge_endpoints(idx).unwrap();
+        let w = graph.edge_weight(idx).unwrap();
+        println!("  {} -> {} : {:.6}", graph[src], graph[dst], w);
+    }
+    for (i, &theta) in state.thresholds.iter().enumerate() {
+        println!("  θ[{i}] = {theta:.6}");
+    }
+}

--- a/examples/hebbian_oja.rs
+++ b/examples/hebbian_oja.rs
@@ -1,0 +1,36 @@
+use petgraph::stable_graph::StableDiGraph;
+use petgraph_live::hebbian::{OjaConfig, oja_update};
+
+fn main() {
+    let mut graph = StableDiGraph::<&str, f64>::new();
+    let x1 = graph.add_node("x1");
+    let x2 = graph.add_node("x2");
+    let y = graph.add_node("y");
+
+    // Two inputs feeding into one output
+    graph.add_edge(x1, y, 0.3);
+    graph.add_edge(x2, y, 0.7);
+
+    let config = OjaConfig { learning_rate: 0.05 };
+
+    println!("--- Oja's rule: weights converge to principal component ---");
+    println!("Initial:");
+    print_edges(&graph);
+
+    // Repeated activations — weights self-normalize
+    for epoch in 1..=50 {
+        oja_update(&mut graph, &[(x1, 0.6), (x2, 0.8)], &[(y, 1.0)], &config);
+        if epoch % 10 == 0 {
+            println!("\nAfter epoch {epoch}:");
+            print_edges(&graph);
+        }
+    }
+}
+
+fn print_edges(graph: &StableDiGraph<&str, f64>) {
+    for idx in graph.edge_indices() {
+        let (src, dst) = graph.edge_endpoints(idx).unwrap();
+        let w = graph.edge_weight(idx).unwrap();
+        println!("  {} -> {} : {:.6}", graph[src], graph[dst], w);
+    }
+}

--- a/examples/hebbian_oja.rs
+++ b/examples/hebbian_oja.rs
@@ -11,7 +11,9 @@ fn main() {
     graph.add_edge(x1, y, 0.3);
     graph.add_edge(x2, y, 0.7);
 
-    let config = OjaConfig { learning_rate: 0.05 };
+    let config = OjaConfig {
+        learning_rate: 0.05,
+    };
 
     println!("--- Oja's rule: weights converge to principal component ---");
     println!("Initial:");

--- a/examples/hebbian_sokm.rs
+++ b/examples/hebbian_sokm.rs
@@ -1,0 +1,56 @@
+use petgraph::stable_graph::StableDiGraph;
+use petgraph_live::hebbian::{sokm_tick, SokmConfig};
+
+fn main() {
+    // Build a small knowledge graph with weighted edges
+    let mut graph = StableDiGraph::<&str, f64>::new();
+    let alice = graph.add_node("alice");
+    let bob = graph.add_node("bob");
+    let carol = graph.add_node("carol");
+    let dave = graph.add_node("dave");
+
+    graph.add_edge(alice, bob, 0.5);
+    graph.add_edge(bob, carol, 0.3);
+    graph.add_edge(carol, dave, 0.1);
+    graph.add_edge(alice, carol, 0.2);
+
+    let config = SokmConfig::default();
+
+    println!("--- Initial graph ({} edges) ---", graph.edge_count());
+    print_edges(&graph);
+
+    // Tick 1: alice and bob co-activate
+    let report = sokm_tick(&mut graph, &[(alice, 1.0), (bob, 0.9)], &config);
+    println!("\n--- After tick 1 (alice + bob active) ---");
+    println!("  {report:?}");
+    print_edges(&graph);
+
+    // Tick 2: bob and carol co-activate
+    let report = sokm_tick(&mut graph, &[(bob, 0.8), (carol, 0.7)], &config);
+    println!("\n--- After tick 2 (bob + carol active) ---");
+    println!("  {report:?}");
+    print_edges(&graph);
+
+    // Tick 3-10: no activation — pure decay + prune
+    for tick in 3..=10 {
+        let report = sokm_tick(&mut graph, &[], &config);
+        if report.pruned > 0 {
+            println!("\n--- Tick {tick}: pruned {} edges ---", report.pruned);
+            print_edges(&graph);
+        }
+    }
+
+    println!("\n--- Final graph ({} edges) ---", graph.edge_count());
+    print_edges(&graph);
+}
+
+fn print_edges(graph: &StableDiGraph<&str, f64>) {
+    for idx in graph.edge_indices() {
+        let (src, dst) = graph.edge_endpoints(idx).unwrap();
+        let w = graph.edge_weight(idx).unwrap();
+        println!(
+            "  {} -> {} : {:.6}",
+            graph[src], graph[dst], w
+        );
+    }
+}

--- a/examples/hebbian_sokm.rs
+++ b/examples/hebbian_sokm.rs
@@ -1,5 +1,5 @@
 use petgraph::stable_graph::StableDiGraph;
-use petgraph_live::hebbian::{sokm_tick, SokmConfig};
+use petgraph_live::hebbian::{SokmConfig, sokm_tick};
 
 fn main() {
     // Build a small knowledge graph with weighted edges
@@ -48,9 +48,6 @@ fn print_edges(graph: &StableDiGraph<&str, f64>) {
     for idx in graph.edge_indices() {
         let (src, dst) = graph.edge_endpoints(idx).unwrap();
         let w = graph.edge_weight(idx).unwrap();
-        println!(
-            "  {} -> {} : {:.6}",
-            graph[src], graph[dst], w
-        );
+        println!("  {} -> {} : {:.6}", graph[src], graph[dst], w);
     }
 }

--- a/examples/hebbian_stdp.rs
+++ b/examples/hebbian_stdp.rs
@@ -1,0 +1,47 @@
+use petgraph::stable_graph::StableDiGraph;
+use petgraph_live::hebbian::{StdpConfig, stdp_update};
+
+fn main() {
+    let mut graph = StableDiGraph::<&str, f64>::new();
+    let sensor = graph.add_node("sensor");
+    let hidden = graph.add_node("hidden");
+    let output = graph.add_node("output");
+
+    graph.add_edge(sensor, hidden, 0.5);
+    graph.add_edge(hidden, output, 0.5);
+    graph.add_edge(sensor, output, 0.3);
+
+    let config = StdpConfig::default();
+
+    println!("--- Initial graph ---");
+    print_edges(&graph);
+
+    // Causal chain: sensor fires first, then hidden, then output
+    let activations = vec![(sensor, 1.0, 1), (hidden, 0.9, 3), (output, 0.8, 5)];
+    let modified = stdp_update(&mut graph, &activations, &config);
+    println!("\n--- After causal chain (sensor@1 → hidden@3 → output@5) ---");
+    println!("  Edges modified: {modified}");
+    print_edges(&graph);
+
+    // Anti-causal: output fires before sensor (prediction error)
+    let activations = vec![(output, 1.0, 10), (sensor, 0.9, 12)];
+    let modified = stdp_update(&mut graph, &activations, &config);
+    println!("\n--- After anti-causal (output@10 → sensor@12) ---");
+    println!("  Edges modified: {modified}");
+    print_edges(&graph);
+
+    // Simultaneous firing: no effect
+    let activations = vec![(sensor, 1.0, 20), (hidden, 1.0, 20)];
+    let modified = stdp_update(&mut graph, &activations, &config);
+    println!("\n--- After simultaneous firing (same tick) ---");
+    println!("  Edges modified: {modified}");
+    print_edges(&graph);
+}
+
+fn print_edges(graph: &StableDiGraph<&str, f64>) {
+    for idx in graph.edge_indices() {
+        let (src, dst) = graph.edge_endpoints(idx).unwrap();
+        let w = graph.edge_weight(idx).unwrap();
+        println!("  {} -> {} : {:.6}", graph[src], graph[dst], w);
+    }
+}

--- a/src/hebbian/anti_hebbian.rs
+++ b/src/hebbian/anti_hebbian.rs
@@ -1,0 +1,139 @@
+//! Anti-Hebbian learning — weaken edges between co-activated nodes.
+//!
+//! Opposite of SOKM strengthen: forces specialization by weakening connections
+//! between nodes that fire together (lateral inhibition).
+
+use petgraph::EdgeType;
+use petgraph::graph::NodeIndex;
+use petgraph::stable_graph::StableGraph;
+
+/// Anti-Hebbian configuration.
+#[derive(Debug, Clone, Copy)]
+pub struct AntiHebbianConfig {
+    /// Weakening rate (default: 0.005).
+    pub beta: f64,
+}
+
+impl Default for AntiHebbianConfig {
+    fn default() -> Self {
+        Self { beta: 0.005 }
+    }
+}
+
+/// Weaken edges between co-activated nodes (lateral inhibition).
+///
+/// For each pair (a, b) in `activated` that has an existing edge,
+/// decrements edge weight by `beta * sa * sb`.
+///
+/// Does **not** create new edges. Does **not** remove edges (use `prune` after).
+/// Returns number of edges weakened.
+///
+/// # Examples
+///
+/// ```
+/// use petgraph::stable_graph::StableDiGraph;
+/// use petgraph_live::hebbian::{anti_hebbian_update, AntiHebbianConfig};
+///
+/// let mut g = StableDiGraph::<(), f64>::new();
+/// let a = g.add_node(());
+/// let b = g.add_node(());
+/// g.add_edge(a, b, 0.5);
+/// g.add_edge(b, a, 0.3);
+///
+/// let weakened = anti_hebbian_update(&mut g, &[(a, 1.0), (b, 0.8)], &AntiHebbianConfig::default());
+/// assert_eq!(weakened, 2);
+/// assert!(*g.edge_weight(0.into()).unwrap() < 0.5);
+/// ```
+pub fn anti_hebbian_update<N, Ty: EdgeType>(
+    graph: &mut StableGraph<N, f64, Ty>,
+    activated: &[(NodeIndex, f64)],
+    config: &AntiHebbianConfig,
+) -> usize {
+    let mut count = 0;
+    for i in 0..activated.len() {
+        let j_start = if Ty::is_directed() { 0 } else { i + 1 };
+        for j in j_start..activated.len() {
+            if i == j {
+                continue;
+            }
+            let (na, sa) = activated[i];
+            let (nb, sb) = activated[j];
+            let decrement = config.beta * sa * sb;
+
+            if let Some(idx) = graph.find_edge(na, nb) {
+                if let Some(w) = graph.edge_weight_mut(idx) {
+                    *w -= decrement;
+                    count += 1;
+                }
+            }
+        }
+    }
+    count
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use petgraph::stable_graph::{StableDiGraph, StableUnGraph};
+
+    #[test]
+    fn co_activated_pair_weakened() {
+        let mut g = StableDiGraph::<(), f64>::new();
+        let a = g.add_node(());
+        let b = g.add_node(());
+        g.add_edge(a, b, 0.5);
+        g.add_edge(b, a, 0.3);
+
+        let config = AntiHebbianConfig::default();
+        anti_hebbian_update(&mut g, &[(a, 1.0), (b, 1.0)], &config);
+
+        // 0.5 - 0.005*1.0*1.0 = 0.495
+        assert!((g.edge_weight(0.into()).unwrap() - 0.495).abs() < 1e-10);
+        // 0.3 - 0.005 = 0.295
+        assert!((g.edge_weight(1.into()).unwrap() - 0.295).abs() < 1e-10);
+    }
+
+    #[test]
+    fn non_activated_pairs_unchanged() {
+        let mut g = StableDiGraph::<(), f64>::new();
+        let a = g.add_node(());
+        let b = g.add_node(());
+        let c = g.add_node(());
+        g.add_edge(a, b, 0.5);
+        g.add_edge(b, c, 0.3);
+
+        let config = AntiHebbianConfig::default();
+        // only a activated — no pairs
+        let count = anti_hebbian_update(&mut g, &[(a, 1.0)], &config);
+        assert_eq!(count, 0);
+        assert_eq!(*g.edge_weight(0.into()).unwrap(), 0.5);
+        assert_eq!(*g.edge_weight(1.into()).unwrap(), 0.3);
+    }
+
+    #[test]
+    fn no_edge_no_effect() {
+        let mut g = StableDiGraph::<(), f64>::new();
+        let a = g.add_node(());
+        let b = g.add_node(());
+        // no edges
+
+        let config = AntiHebbianConfig::default();
+        let count = anti_hebbian_update(&mut g, &[(a, 1.0), (b, 1.0)], &config);
+        assert_eq!(count, 0);
+        assert_eq!(g.edge_count(), 0);
+    }
+
+    #[test]
+    fn undirected_anti_hebbian() {
+        let mut g = StableUnGraph::<(), f64>::with_capacity(0, 0);
+        let a = g.add_node(());
+        let b = g.add_node(());
+        g.add_edge(a, b, 0.5);
+
+        let config = AntiHebbianConfig { beta: 0.01 };
+        let count = anti_hebbian_update(&mut g, &[(a, 1.0), (b, 0.8)], &config);
+        assert_eq!(count, 1);
+        // 0.5 - 0.01*1.0*0.8 = 0.492
+        assert!((g.edge_weight(0.into()).unwrap() - 0.492).abs() < 1e-10);
+    }
+}

--- a/src/hebbian/anti_hebbian.rs
+++ b/src/hebbian/anti_hebbian.rs
@@ -60,11 +60,11 @@ pub fn anti_hebbian_update<N, Ty: EdgeType>(
             let (nb, sb) = activated[j];
             let decrement = config.beta * sa * sb;
 
-            if let Some(idx) = graph.find_edge(na, nb) {
-                if let Some(w) = graph.edge_weight_mut(idx) {
-                    *w -= decrement;
-                    count += 1;
-                }
+            if let Some(idx) = graph.find_edge(na, nb)
+                && let Some(w) = graph.edge_weight_mut(idx)
+            {
+                *w -= decrement;
+                count += 1;
             }
         }
     }

--- a/src/hebbian/bcm.rs
+++ b/src/hebbian/bcm.rs
@@ -1,0 +1,196 @@
+//! BCM (Bienenstock-Cooper-Munro) rule — homeostatic plasticity.
+//!
+//! Activity-dependent threshold: highly active nodes become harder to strengthen.
+//! Prevents runaway strengthening and stabilizes the network.
+
+use petgraph::EdgeType;
+use petgraph::graph::NodeIndex;
+use petgraph::stable_graph::StableGraph;
+
+/// BCM configuration.
+#[derive(Debug, Clone, Copy)]
+pub struct BcmConfig {
+    /// Learning rate (default: 0.01).
+    pub learning_rate: f64,
+    /// Threshold sliding rate (default: 0.001).
+    pub threshold_rate: f64,
+}
+
+impl Default for BcmConfig {
+    fn default() -> Self {
+        Self {
+            learning_rate: 0.01,
+            threshold_rate: 0.001,
+        }
+    }
+}
+
+/// BCM state — tracks per-node sliding threshold.
+#[derive(Debug, Clone)]
+pub struct BcmState {
+    /// Per-node activity threshold (indexed by `NodeIndexable::to_index`).
+    pub thresholds: Vec<f64>,
+}
+
+impl BcmState {
+    /// Create state for a graph with `n` nodes, initialized to `initial_threshold`.
+    pub fn new(n: usize, initial_threshold: f64) -> Self {
+        Self {
+            thresholds: vec![initial_threshold; n],
+        }
+    }
+}
+
+/// Apply BCM rule: strengthen if activation > threshold, weaken if below.
+///
+/// For each edge (pre → post) where both are in `activated`:
+///   Δw = η × y_post × (y_post − θ_post) × x_pre
+///
+/// Thresholds slide toward recent activity:
+///   Δθ = threshold_rate × (y² − θ)
+///
+/// Returns number of edges modified.
+///
+/// # Examples
+///
+/// ```
+/// use petgraph::stable_graph::StableDiGraph;
+/// use petgraph_live::hebbian::{bcm_update, BcmConfig, BcmState};
+///
+/// let mut g = StableDiGraph::<(), f64>::new();
+/// let a = g.add_node(());
+/// let b = g.add_node(());
+/// g.add_edge(a, b, 0.5);
+///
+/// let mut state = BcmState::new(2, 0.5);
+/// let modified = bcm_update(&mut g, &[(a, 0.8), (b, 0.9)], &mut state, &BcmConfig::default());
+/// assert_eq!(modified, 1);
+/// ```
+pub fn bcm_update<N, Ty: EdgeType>(
+    graph: &mut StableGraph<N, f64, Ty>,
+    activated: &[(NodeIndex, f64)],
+    state: &mut BcmState,
+    config: &BcmConfig,
+) -> usize {
+    // Update thresholds for all activated nodes
+    for &(node, y) in activated {
+        let idx = node.index();
+        if idx < state.thresholds.len() {
+            let theta = &mut state.thresholds[idx];
+            *theta += config.threshold_rate * (y * y - *theta);
+        }
+    }
+
+    // Modify edges between activated pairs
+    let mut modified = 0;
+    for i in 0..activated.len() {
+        let j_start = if Ty::is_directed() { 0 } else { i + 1 };
+        for j in j_start..activated.len() {
+            if i == j {
+                continue;
+            }
+            let (pre_node, x) = activated[i];
+            let (post_node, y) = activated[j];
+            let post_idx = post_node.index();
+            if post_idx >= state.thresholds.len() {
+                continue;
+            }
+            let theta = state.thresholds[post_idx];
+            // Δw = η × y × (y − θ) × x
+            let delta_w = config.learning_rate * y * (y - theta) * x;
+
+            if let Some(edge_idx) = graph.find_edge(pre_node, post_node) {
+                if let Some(w) = graph.edge_weight_mut(edge_idx) {
+                    *w += delta_w;
+                    modified += 1;
+                }
+            }
+        }
+    }
+    modified
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use petgraph::stable_graph::StableDiGraph;
+
+    #[test]
+    fn above_threshold_strengthens() {
+        let mut g = StableDiGraph::<(), f64>::new();
+        let a = g.add_node(());
+        let b = g.add_node(());
+        g.add_edge(a, b, 0.5);
+
+        // threshold=0.3, activation=0.9 → above threshold → strengthen
+        let mut state = BcmState::new(2, 0.3);
+        let config = BcmConfig::default();
+        bcm_update(&mut g, &[(a, 0.9), (b, 0.9)], &mut state, &config);
+        assert!(*g.edge_weight(0.into()).unwrap() > 0.5);
+    }
+
+    #[test]
+    fn below_threshold_weakens() {
+        let mut g = StableDiGraph::<(), f64>::new();
+        let a = g.add_node(());
+        let b = g.add_node(());
+        g.add_edge(a, b, 0.5);
+
+        // threshold=0.9, activation=0.3 → below threshold → weaken
+        let mut state = BcmState::new(2, 0.9);
+        let config = BcmConfig::default();
+        bcm_update(&mut g, &[(a, 0.3), (b, 0.3)], &mut state, &config);
+        assert!(*g.edge_weight(0.into()).unwrap() < 0.5);
+    }
+
+    #[test]
+    fn threshold_slides_toward_activity() {
+        let mut g = StableDiGraph::<(), f64>::new();
+        let a = g.add_node(());
+        let _b = g.add_node(());
+
+        let mut state = BcmState::new(2, 0.5);
+        let config = BcmConfig {
+            threshold_rate: 0.1,
+            ..BcmConfig::default()
+        };
+
+        // Activate a with y=1.0 → threshold moves toward y²=1.0
+        bcm_update(&mut g, &[(a, 1.0)], &mut state, &config);
+        // θ += 0.1 * (1.0 - 0.5) = 0.55
+        assert!((state.thresholds[0] - 0.55).abs() < 1e-10);
+    }
+
+    #[test]
+    fn no_edge_no_modification() {
+        let mut g = StableDiGraph::<(), f64>::new();
+        let a = g.add_node(());
+        let b = g.add_node(());
+
+        let mut state = BcmState::new(2, 0.5);
+        let modified = bcm_update(&mut g, &[(a, 0.8), (b, 0.8)], &mut state, &BcmConfig::default());
+        assert_eq!(modified, 0);
+    }
+
+    #[test]
+    fn repeated_high_activity_raises_threshold() {
+        let mut g = StableDiGraph::<(), f64>::new();
+        let a = g.add_node(());
+        let b = g.add_node(());
+        g.add_edge(a, b, 0.5);
+
+        let mut state = BcmState::new(2, 0.1);
+        let config = BcmConfig {
+            threshold_rate: 0.5,
+            learning_rate: 0.01,
+            ..BcmConfig::default()
+        };
+
+        // Repeated high activation raises threshold → eventually weakens
+        for _ in 0..20 {
+            bcm_update(&mut g, &[(a, 1.0), (b, 1.0)], &mut state, &config);
+        }
+        // Threshold for b should be near 1.0 (y²=1.0)
+        assert!(state.thresholds[1] > 0.9);
+    }
+}

--- a/src/hebbian/bcm.rs
+++ b/src/hebbian/bcm.rs
@@ -99,11 +99,11 @@ pub fn bcm_update<N, Ty: EdgeType>(
             // Δw = η × y × (y − θ) × x
             let delta_w = config.learning_rate * y * (y - theta) * x;
 
-            if let Some(edge_idx) = graph.find_edge(pre_node, post_node) {
-                if let Some(w) = graph.edge_weight_mut(edge_idx) {
-                    *w += delta_w;
-                    modified += 1;
-                }
+            if let Some(edge_idx) = graph.find_edge(pre_node, post_node)
+                && let Some(w) = graph.edge_weight_mut(edge_idx)
+            {
+                *w += delta_w;
+                modified += 1;
             }
         }
     }
@@ -168,7 +168,12 @@ mod tests {
         let b = g.add_node(());
 
         let mut state = BcmState::new(2, 0.5);
-        let modified = bcm_update(&mut g, &[(a, 0.8), (b, 0.8)], &mut state, &BcmConfig::default());
+        let modified = bcm_update(
+            &mut g,
+            &[(a, 0.8), (b, 0.8)],
+            &mut state,
+            &BcmConfig::default(),
+        );
         assert_eq!(modified, 0);
     }
 
@@ -183,7 +188,6 @@ mod tests {
         let config = BcmConfig {
             threshold_rate: 0.5,
             learning_rate: 0.01,
-            ..BcmConfig::default()
         };
 
         // Repeated high activation raises threshold → eventually weakens

--- a/src/hebbian/mod.rs
+++ b/src/hebbian/mod.rs
@@ -4,6 +4,8 @@
 //! - **SOKM** — decay → strengthen → prune per tick (cooperative)
 //! - **STDP** — spike-timing dependent plasticity (temporal)
 //! - **Anti-Hebbian** — lateral inhibition (competitive)
+//! - **Oja** — normalized Hebbian, self-converging weights
+//! - **BCM** — homeostatic plasticity with sliding threshold
 //!
 //! # Examples
 //!
@@ -21,9 +23,13 @@
 //! ```
 
 mod anti_hebbian;
+mod bcm;
+mod oja;
 mod sokm;
 mod stdp;
 
 pub use anti_hebbian::{AntiHebbianConfig, anti_hebbian_update};
+pub use bcm::{BcmConfig, BcmState, bcm_update};
+pub use oja::{OjaConfig, oja_update};
 pub use sokm::{HebbianReport, SokmConfig, StrengthFormula, decay, prune, sokm_tick, strengthen};
 pub use stdp::{StdpConfig, TimedActivation, stdp_update};

--- a/src/hebbian/mod.rs
+++ b/src/hebbian/mod.rs
@@ -1,0 +1,25 @@
+//! Hebbian learning on graphs: self-organizing dynamics that modify edge weights.
+//!
+//! The primary algorithm is **SOKM** (Self-Organizing Knowledge Map):
+//! decay → strengthen → prune per tick.
+//!
+//! # Examples
+//!
+//! ```
+//! use petgraph::stable_graph::StableDiGraph;
+//! use petgraph_live::hebbian::{sokm_tick, SokmConfig};
+//!
+//! let mut graph = StableDiGraph::<&str, f64>::new();
+//! let a = graph.add_node("A");
+//! let b = graph.add_node("B");
+//! graph.add_edge(a, b, 0.5);
+//!
+//! let activated = vec![(a, 1.0), (b, 0.8)];
+//! let report = sokm_tick(&mut graph, &activated, &SokmConfig::default());
+//! ```
+
+mod sokm;
+
+pub use sokm::{
+    decay, prune, sokm_tick, strengthen, HebbianReport, SokmConfig, StrengthFormula,
+};

--- a/src/hebbian/mod.rs
+++ b/src/hebbian/mod.rs
@@ -1,7 +1,9 @@
 //! Hebbian learning on graphs: self-organizing dynamics that modify edge weights.
 //!
-//! The primary algorithm is **SOKM** (Self-Organizing Knowledge Map):
-//! decay → strengthen → prune per tick.
+//! Algorithms:
+//! - **SOKM** — decay → strengthen → prune per tick (cooperative)
+//! - **STDP** — spike-timing dependent plasticity (temporal)
+//! - **Anti-Hebbian** — lateral inhibition (competitive)
 //!
 //! # Examples
 //!
@@ -18,8 +20,10 @@
 //! let report = sokm_tick(&mut graph, &activated, &SokmConfig::default());
 //! ```
 
+mod anti_hebbian;
 mod sokm;
+mod stdp;
 
-pub use sokm::{
-    decay, prune, sokm_tick, strengthen, HebbianReport, SokmConfig, StrengthFormula,
-};
+pub use anti_hebbian::{AntiHebbianConfig, anti_hebbian_update};
+pub use sokm::{HebbianReport, SokmConfig, StrengthFormula, decay, prune, sokm_tick, strengthen};
+pub use stdp::{StdpConfig, TimedActivation, stdp_update};

--- a/src/hebbian/oja.rs
+++ b/src/hebbian/oja.rs
@@ -1,0 +1,140 @@
+//! Oja's rule — normalized Hebbian learning.
+//!
+//! Self-normalizing: weights converge without manual capping.
+//! Δw_ij = η × y_i × (x_j − w_ij × y_i)
+
+use petgraph::EdgeType;
+use petgraph::graph::NodeIndex;
+use petgraph::stable_graph::StableGraph;
+
+/// Oja's rule configuration.
+#[derive(Debug, Clone, Copy)]
+pub struct OjaConfig {
+    /// Learning rate (default: 0.01).
+    pub learning_rate: f64,
+}
+
+impl Default for OjaConfig {
+    fn default() -> Self {
+        Self { learning_rate: 0.01 }
+    }
+}
+
+/// Apply Oja's normalized Hebbian rule.
+///
+/// For each edge (pre → post) where pre is in `pre_activations` and post is in
+/// `post_activations`, updates weight:
+///   Δw = η × y_post × (x_pre − w × y_post)
+///
+/// Self-normalizing — weights converge to principal component direction.
+/// Returns number of edges modified.
+///
+/// # Examples
+///
+/// ```
+/// use petgraph::stable_graph::StableDiGraph;
+/// use petgraph_live::hebbian::{oja_update, OjaConfig};
+///
+/// let mut g = StableDiGraph::<(), f64>::new();
+/// let a = g.add_node(());
+/// let b = g.add_node(());
+/// g.add_edge(a, b, 0.5);
+///
+/// let pre = vec![(a, 1.0)];
+/// let post = vec![(b, 0.8)];
+/// let modified = oja_update(&mut g, &pre, &post, &OjaConfig::default());
+/// assert_eq!(modified, 1);
+/// ```
+pub fn oja_update<N, Ty: EdgeType>(
+    graph: &mut StableGraph<N, f64, Ty>,
+    pre_activations: &[(NodeIndex, f64)],
+    post_activations: &[(NodeIndex, f64)],
+    config: &OjaConfig,
+) -> usize {
+    let mut modified = 0;
+    for &(post_node, y) in post_activations {
+        for &(pre_node, x) in pre_activations {
+            if pre_node == post_node {
+                continue;
+            }
+            if let Some(idx) = graph.find_edge(pre_node, post_node) {
+                if let Some(w) = graph.edge_weight_mut(idx) {
+                    // Δw = η × y × (x − w × y)
+                    *w += config.learning_rate * y * (x - *w * y);
+                    modified += 1;
+                }
+            }
+        }
+    }
+    modified
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use petgraph::stable_graph::StableDiGraph;
+
+    #[test]
+    fn oja_converges_toward_normalization() {
+        let mut g = StableDiGraph::<(), f64>::new();
+        let a = g.add_node(());
+        let b = g.add_node(());
+        g.add_edge(a, b, 0.5);
+
+        let config = OjaConfig { learning_rate: 0.1 };
+        // Repeated application with constant activations converges
+        for _ in 0..100 {
+            oja_update(&mut g, &[(a, 1.0)], &[(b, 1.0)], &config);
+        }
+        // With x=1, y=1: converges to w where η*y*(x - w*y) = 0 → w = x/y = 1.0
+        let w = *g.edge_weight(0.into()).unwrap();
+        assert!((w - 1.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn oja_no_edge_no_effect() {
+        let mut g = StableDiGraph::<(), f64>::new();
+        let a = g.add_node(());
+        let b = g.add_node(());
+
+        let modified = oja_update(&mut g, &[(a, 1.0)], &[(b, 1.0)], &OjaConfig::default());
+        assert_eq!(modified, 0);
+        assert_eq!(g.edge_count(), 0);
+    }
+
+    #[test]
+    fn oja_self_loop_skipped() {
+        let mut g = StableDiGraph::<(), f64>::new();
+        let a = g.add_node(());
+        g.add_edge(a, a, 0.5);
+
+        let modified = oja_update(&mut g, &[(a, 1.0)], &[(a, 1.0)], &OjaConfig::default());
+        assert_eq!(modified, 0);
+        assert_eq!(*g.edge_weight(0.into()).unwrap(), 0.5);
+    }
+
+    #[test]
+    fn oja_high_weight_decreases() {
+        let mut g = StableDiGraph::<(), f64>::new();
+        let a = g.add_node(());
+        let b = g.add_node(());
+        g.add_edge(a, b, 2.0); // w > x/y → should decrease
+
+        let config = OjaConfig { learning_rate: 0.1 };
+        oja_update(&mut g, &[(a, 1.0)], &[(b, 1.0)], &config);
+        // Δw = 0.1 * 1.0 * (1.0 - 2.0*1.0) = -0.1
+        assert!(*g.edge_weight(0.into()).unwrap() < 2.0);
+    }
+
+    #[test]
+    fn oja_low_weight_increases() {
+        let mut g = StableDiGraph::<(), f64>::new();
+        let a = g.add_node(());
+        let b = g.add_node(());
+        g.add_edge(a, b, 0.1); // w < x/y → should increase
+
+        let config = OjaConfig { learning_rate: 0.1 };
+        oja_update(&mut g, &[(a, 1.0)], &[(b, 1.0)], &config);
+        assert!(*g.edge_weight(0.into()).unwrap() > 0.1);
+    }
+}

--- a/src/hebbian/oja.rs
+++ b/src/hebbian/oja.rs
@@ -16,7 +16,9 @@ pub struct OjaConfig {
 
 impl Default for OjaConfig {
     fn default() -> Self {
-        Self { learning_rate: 0.01 }
+        Self {
+            learning_rate: 0.01,
+        }
     }
 }
 
@@ -57,12 +59,12 @@ pub fn oja_update<N, Ty: EdgeType>(
             if pre_node == post_node {
                 continue;
             }
-            if let Some(idx) = graph.find_edge(pre_node, post_node) {
-                if let Some(w) = graph.edge_weight_mut(idx) {
-                    // Δw = η × y × (x − w × y)
-                    *w += config.learning_rate * y * (x - *w * y);
-                    modified += 1;
-                }
+            if let Some(idx) = graph.find_edge(pre_node, post_node)
+                && let Some(w) = graph.edge_weight_mut(idx)
+            {
+                // Δw = η × y × (x − w × y)
+                *w += config.learning_rate * y * (x - *w * y);
+                modified += 1;
             }
         }
     }

--- a/src/hebbian/sokm.rs
+++ b/src/hebbian/sokm.rs
@@ -1,7 +1,8 @@
 //! SOKM (Self-Organizing Knowledge Map) — decay → strengthen → prune.
 
+use petgraph::EdgeType;
 use petgraph::graph::NodeIndex;
-use petgraph::stable_graph::StableDiGraph;
+use petgraph::stable_graph::StableGraph;
 
 /// Configuration for SOKM dynamics.
 #[derive(Debug, Clone, Copy)]
@@ -66,7 +67,7 @@ pub struct HebbianReport {
 /// assert_eq!(decay(&mut g, 0.5), 1);
 /// assert_eq!(*g.edge_weight(0.into()).unwrap(), 0.5);
 /// ```
-pub fn decay<N>(graph: &mut StableDiGraph<N, f64>, factor: f64) -> usize {
+pub fn decay<N, Ty: EdgeType>(graph: &mut StableGraph<N, f64, Ty>, factor: f64) -> usize {
     let indices: Vec<_> = graph.edge_indices().collect();
     for &idx in &indices {
         if let Some(w) = graph.edge_weight_mut(idx) {
@@ -78,10 +79,13 @@ pub fn decay<N>(graph: &mut StableDiGraph<N, f64>, factor: f64) -> usize {
 
 /// Strengthen edges between co-activated node pairs.
 ///
-/// For each ordered pair (a, b) in `activated`, increments the edge weight
+/// For each pair (a, b) in `activated`, increments the edge weight
 /// using the configured formula. Creates the edge if it does not exist.
 ///
-/// Returns number of pairs strengthened.
+/// For directed graphs, both (a→b) and (b→a) are processed.
+/// For undirected graphs, each unordered pair is processed once.
+///
+/// Returns number of edges strengthened.
 ///
 /// # Examples
 ///
@@ -100,14 +104,15 @@ pub fn decay<N>(graph: &mut StableDiGraph<N, f64>, factor: f64) -> usize {
 /// assert_eq!(count, 2); // a→b and b→a
 /// assert_eq!(g.edge_count(), 2);
 /// ```
-pub fn strengthen<N>(
-    graph: &mut StableDiGraph<N, f64>,
+pub fn strengthen<N, Ty: EdgeType>(
+    graph: &mut StableGraph<N, f64, Ty>,
     activated: &[(NodeIndex, f64)],
     config: &SokmConfig,
 ) -> usize {
     let mut count = 0;
     for i in 0..activated.len() {
-        for j in 0..activated.len() {
+        let j_start = if Ty::is_directed() { 0 } else { i + 1 };
+        for j in j_start..activated.len() {
             if i == j {
                 continue;
             }
@@ -148,14 +153,10 @@ pub fn strengthen<N>(
 /// assert_eq!(prune(&mut g, 0.001), 1);
 /// assert_eq!(g.edge_count(), 1);
 /// ```
-pub fn prune<N>(graph: &mut StableDiGraph<N, f64>, threshold: f64) -> usize {
+pub fn prune<N, Ty: EdgeType>(graph: &mut StableGraph<N, f64, Ty>, threshold: f64) -> usize {
     let to_remove: Vec<_> = graph
         .edge_indices()
-        .filter(|&idx| {
-            graph
-                .edge_weight(idx)
-                .map_or(false, |&w| w < threshold)
-        })
+        .filter(|&idx| graph.edge_weight(idx).map_or(false, |&w| w < threshold))
         .collect();
     let count = to_remove.len();
     for idx in to_remove {
@@ -181,8 +182,8 @@ pub fn prune<N>(graph: &mut StableDiGraph<N, f64>, threshold: f64) -> usize {
 /// assert_eq!(report.decayed, 1);
 /// assert!(report.strengthened > 0);
 /// ```
-pub fn sokm_tick<N>(
-    graph: &mut StableDiGraph<N, f64>,
+pub fn sokm_tick<N, Ty: EdgeType>(
+    graph: &mut StableGraph<N, f64, Ty>,
     activated: &[(NodeIndex, f64)],
     config: &SokmConfig,
 ) -> HebbianReport {
@@ -199,6 +200,7 @@ pub fn sokm_tick<N>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use petgraph::stable_graph::{StableDiGraph, StableUnGraph};
 
     fn make_graph() -> StableDiGraph<(), f64> {
         let mut g = StableDiGraph::new();
@@ -236,7 +238,7 @@ mod tests {
     #[test]
     fn prune_removes_below_threshold() {
         let mut g = make_graph();
-        assert_eq!(prune(&mut g, 0.1), 1); // removes 0.01 edge
+        assert_eq!(prune(&mut g, 0.1), 1);
         assert_eq!(g.edge_count(), 2);
     }
 
@@ -252,7 +254,6 @@ mod tests {
         let mut g = StableDiGraph::<(), f64>::new();
         let a = g.add_node(());
         let b = g.add_node(());
-        assert_eq!(g.edge_count(), 0);
 
         let config = SokmConfig::default();
         strengthen(&mut g, &[(a, 1.0), (b, 1.0)], &config);
@@ -282,12 +283,11 @@ mod tests {
     fn strengthen_non_activated_pairs_unchanged() {
         let mut g = StableDiGraph::<(), f64>::new();
         let a = g.add_node(());
-        let b = g.add_node(());
+        let _b = g.add_node(());
         let c = g.add_node(());
-        g.add_edge(b, c, 0.5);
+        g.add_edge(a, c, 0.5);
 
         let config = SokmConfig::default();
-        // only a is activated — no pairs to strengthen
         strengthen(&mut g, &[(a, 1.0)], &config);
         assert_eq!(*g.edge_weight(0.into()).unwrap(), 0.5);
     }
@@ -301,7 +301,6 @@ mod tests {
 
         let config = SokmConfig::default();
         strengthen(&mut g, &[(a, 1.0), (b, 1.0)], &config);
-        // 0.5 + 0.02*1.0*1.0 = 0.52
         assert!((g.edge_weight(0.into()).unwrap() - 0.52).abs() < 1e-10);
     }
 
@@ -310,14 +309,12 @@ mod tests {
         let mut g = StableDiGraph::<(), f64>::new();
         let a = g.add_node(());
         let b = g.add_node(());
-        g.add_edge(a, b, 0.0005); // will be pruned after decay
+        g.add_edge(a, b, 0.0005);
 
         let config = SokmConfig::default();
         let report = sokm_tick(&mut g, &[(a, 1.0), (b, 1.0)], &config);
         assert_eq!(report.decayed, 1);
         assert_eq!(report.strengthened, 2);
-        // 0.0005 * 0.95 = 0.000475, then +0.02 = 0.020475, not pruned
-        // But b→a is newly created at 0.02, not pruned either
         assert_eq!(report.pruned, 0);
     }
 
@@ -327,7 +324,7 @@ mod tests {
         let a = g.add_node(());
         let b = g.add_node(());
         let c = g.add_node(());
-        g.add_edge(a, c, 0.0005); // decays to 0.000475, no co-activation → pruned
+        g.add_edge(a, c, 0.0005);
 
         let config = SokmConfig::default();
         let report = sokm_tick(&mut g, &[(a, 1.0), (b, 1.0)], &config);
@@ -345,7 +342,6 @@ mod tests {
             ..SokmConfig::default()
         };
         strengthen(&mut g, &[(a, 0.8), (b, 0.3)], &config);
-        // delta * min(0.8, 0.3) = 0.02 * 0.3 = 0.006
         assert!((g.edge_weight(0.into()).unwrap() - 0.006).abs() < 1e-10);
     }
 
@@ -360,7 +356,37 @@ mod tests {
             ..SokmConfig::default()
         };
         strengthen(&mut g, &[(a, 0.8), (b, 0.4)], &config);
-        // delta * (0.8 + 0.4) / 2 = 0.02 * 0.6 = 0.012
         assert!((g.edge_weight(0.into()).unwrap() - 0.012).abs() < 1e-10);
+    }
+
+    #[test]
+    fn undirected_strengthen_single_edge_per_pair() {
+        let mut g = StableUnGraph::<(), f64>::with_capacity(0, 0);
+        let a = g.add_node(());
+        let b = g.add_node(());
+
+        let config = SokmConfig::default();
+        let count = strengthen(&mut g, &[(a, 1.0), (b, 1.0)], &config);
+        // Undirected: only one edge created for pair (a,b)
+        assert_eq!(count, 1);
+        assert_eq!(g.edge_count(), 1);
+        assert!((g.edge_weight(0.into()).unwrap() - 0.02).abs() < 1e-10);
+    }
+
+    #[test]
+    fn undirected_sokm_tick() {
+        let mut g = StableUnGraph::<(), f64>::with_capacity(0, 0);
+        let a = g.add_node(());
+        let b = g.add_node(());
+        let c = g.add_node(());
+        g.add_edge(a, b, 0.5);
+        g.add_edge(b, c, 0.0005);
+
+        let config = SokmConfig::default();
+        let report = sokm_tick(&mut g, &[(a, 1.0), (b, 0.9)], &config);
+        assert_eq!(report.decayed, 2);
+        assert_eq!(report.strengthened, 1);
+        // b-c: 0.0005*0.95 = 0.000475 < 0.001 → pruned
+        assert_eq!(report.pruned, 1);
     }
 }

--- a/src/hebbian/sokm.rs
+++ b/src/hebbian/sokm.rs
@@ -220,10 +220,31 @@ mod tests {
     }
 
     #[test]
+    fn decay_repeated_converges() {
+        let mut g = StableDiGraph::<(), f64>::new();
+        let a = g.add_node(());
+        let b = g.add_node(());
+        g.add_edge(a, b, 1.0);
+
+        for _ in 0..10 {
+            decay(&mut g, 0.95);
+        }
+        let expected = 0.95f64.powi(10);
+        assert!((g.edge_weight(0.into()).unwrap() - expected).abs() < 1e-10);
+    }
+
+    #[test]
     fn prune_removes_below_threshold() {
         let mut g = make_graph();
         assert_eq!(prune(&mut g, 0.1), 1); // removes 0.01 edge
         assert_eq!(g.edge_count(), 2);
+    }
+
+    #[test]
+    fn prune_retains_above_threshold() {
+        let mut g = make_graph();
+        assert_eq!(prune(&mut g, 0.001), 0);
+        assert_eq!(g.edge_count(), 3);
     }
 
     #[test]
@@ -236,6 +257,39 @@ mod tests {
         let config = SokmConfig::default();
         strengthen(&mut g, &[(a, 1.0), (b, 1.0)], &config);
         assert_eq!(g.edge_count(), 2); // a→b and b→a
+    }
+
+    #[test]
+    fn strengthen_higher_scores_get_more() {
+        let mut g1 = StableDiGraph::<(), f64>::new();
+        let a1 = g1.add_node(());
+        let b1 = g1.add_node(());
+
+        let mut g2 = StableDiGraph::<(), f64>::new();
+        let a2 = g2.add_node(());
+        let b2 = g2.add_node(());
+
+        let config = SokmConfig::default();
+        strengthen(&mut g1, &[(a1, 0.5), (b1, 0.5)], &config);
+        strengthen(&mut g2, &[(a2, 1.0), (b2, 1.0)], &config);
+
+        let w1 = *g1.edge_weight(g1.find_edge(a1, b1).unwrap()).unwrap();
+        let w2 = *g2.edge_weight(g2.find_edge(a2, b2).unwrap()).unwrap();
+        assert!(w2 > w1);
+    }
+
+    #[test]
+    fn strengthen_non_activated_pairs_unchanged() {
+        let mut g = StableDiGraph::<(), f64>::new();
+        let a = g.add_node(());
+        let b = g.add_node(());
+        let c = g.add_node(());
+        g.add_edge(b, c, 0.5);
+
+        let config = SokmConfig::default();
+        // only a is activated — no pairs to strengthen
+        strengthen(&mut g, &[(a, 1.0)], &config);
+        assert_eq!(*g.edge_weight(0.into()).unwrap(), 0.5);
     }
 
     #[test]

--- a/src/hebbian/sokm.rs
+++ b/src/hebbian/sokm.rs
@@ -156,7 +156,7 @@ pub fn strengthen<N, Ty: EdgeType>(
 pub fn prune<N, Ty: EdgeType>(graph: &mut StableGraph<N, f64, Ty>, threshold: f64) -> usize {
     let to_remove: Vec<_> = graph
         .edge_indices()
-        .filter(|&idx| graph.edge_weight(idx).map_or(false, |&w| w < threshold))
+        .filter(|&idx| graph.edge_weight(idx).is_some_and(|&w| w < threshold))
         .collect();
     let count = to_remove.len();
     for idx in to_remove {

--- a/src/hebbian/sokm.rs
+++ b/src/hebbian/sokm.rs
@@ -1,0 +1,312 @@
+//! SOKM (Self-Organizing Knowledge Map) — decay → strengthen → prune.
+
+use petgraph::graph::NodeIndex;
+use petgraph::stable_graph::StableDiGraph;
+
+/// Configuration for SOKM dynamics.
+#[derive(Debug, Clone, Copy)]
+pub struct SokmConfig {
+    /// Multiplicative decay per tick (default: 0.95).
+    pub decay_factor: f64,
+    /// Base increment for co-activation strengthening (default: 0.02).
+    pub delta: f64,
+    /// Prune threshold — edges below this are removed (default: 0.001).
+    pub min_weight: f64,
+    /// Formula for combining activation scores.
+    pub formula: StrengthFormula,
+}
+
+impl Default for SokmConfig {
+    fn default() -> Self {
+        Self {
+            decay_factor: 0.95,
+            delta: 0.02,
+            min_weight: 0.001,
+            formula: StrengthFormula::default(),
+        }
+    }
+}
+
+/// Strengthening formula — how activation scores combine.
+#[derive(Debug, Clone, Copy, Default)]
+pub enum StrengthFormula {
+    /// `delta * sa * sb` — product, confidence amplifier.
+    #[default]
+    Product,
+    /// `delta * min(sa, sb)` — weakest link.
+    Min,
+    /// `delta * (sa + sb) / 2` — average.
+    Average,
+}
+
+/// Report from a SOKM tick.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct HebbianReport {
+    /// Edges that had decay applied.
+    pub decayed: usize,
+    /// Co-activated pairs that were strengthened.
+    pub strengthened: usize,
+    /// Edges removed by pruning.
+    pub pruned: usize,
+}
+
+/// Multiply all edge weights by `factor`. Returns count of edges decayed.
+///
+/// # Examples
+///
+/// ```
+/// use petgraph::stable_graph::StableDiGraph;
+/// use petgraph_live::hebbian::decay;
+///
+/// let mut g = StableDiGraph::<(), f64>::new();
+/// let a = g.add_node(());
+/// let b = g.add_node(());
+/// g.add_edge(a, b, 1.0);
+///
+/// assert_eq!(decay(&mut g, 0.5), 1);
+/// assert_eq!(*g.edge_weight(0.into()).unwrap(), 0.5);
+/// ```
+pub fn decay<N>(graph: &mut StableDiGraph<N, f64>, factor: f64) -> usize {
+    let indices: Vec<_> = graph.edge_indices().collect();
+    for &idx in &indices {
+        if let Some(w) = graph.edge_weight_mut(idx) {
+            *w *= factor;
+        }
+    }
+    indices.len()
+}
+
+/// Strengthen edges between co-activated node pairs.
+///
+/// For each ordered pair (a, b) in `activated`, increments the edge weight
+/// using the configured formula. Creates the edge if it does not exist.
+///
+/// Returns number of pairs strengthened.
+///
+/// # Examples
+///
+/// ```
+/// use petgraph::stable_graph::StableDiGraph;
+/// use petgraph_live::hebbian::{strengthen, SokmConfig};
+///
+/// let mut g = StableDiGraph::<(), f64>::new();
+/// let a = g.add_node(());
+/// let b = g.add_node(());
+///
+/// let activated = vec![(a, 1.0), (b, 0.5)];
+/// let config = SokmConfig::default();
+/// let count = strengthen(&mut g, &activated, &config);
+///
+/// assert_eq!(count, 2); // a→b and b→a
+/// assert_eq!(g.edge_count(), 2);
+/// ```
+pub fn strengthen<N>(
+    graph: &mut StableDiGraph<N, f64>,
+    activated: &[(NodeIndex, f64)],
+    config: &SokmConfig,
+) -> usize {
+    let mut count = 0;
+    for i in 0..activated.len() {
+        for j in 0..activated.len() {
+            if i == j {
+                continue;
+            }
+            let (na, sa) = activated[i];
+            let (nb, sb) = activated[j];
+            let increment = match config.formula {
+                StrengthFormula::Product => config.delta * sa * sb,
+                StrengthFormula::Min => config.delta * sa.min(sb),
+                StrengthFormula::Average => config.delta * (sa + sb) / 2.0,
+            };
+            if let Some(idx) = graph.find_edge(na, nb) {
+                if let Some(w) = graph.edge_weight_mut(idx) {
+                    *w += increment;
+                }
+            } else {
+                graph.add_edge(na, nb, increment);
+            }
+            count += 1;
+        }
+    }
+    count
+}
+
+/// Remove edges with weight below `threshold`. Returns count removed.
+///
+/// # Examples
+///
+/// ```
+/// use petgraph::stable_graph::StableDiGraph;
+/// use petgraph_live::hebbian::prune;
+///
+/// let mut g = StableDiGraph::<(), f64>::new();
+/// let a = g.add_node(());
+/// let b = g.add_node(());
+/// g.add_edge(a, b, 0.0001);
+/// g.add_edge(b, a, 0.5);
+///
+/// assert_eq!(prune(&mut g, 0.001), 1);
+/// assert_eq!(g.edge_count(), 1);
+/// ```
+pub fn prune<N>(graph: &mut StableDiGraph<N, f64>, threshold: f64) -> usize {
+    let to_remove: Vec<_> = graph
+        .edge_indices()
+        .filter(|&idx| {
+            graph
+                .edge_weight(idx)
+                .map_or(false, |&w| w < threshold)
+        })
+        .collect();
+    let count = to_remove.len();
+    for idx in to_remove {
+        graph.remove_edge(idx);
+    }
+    count
+}
+
+/// Full SOKM tick: decay → strengthen → prune.
+///
+/// # Examples
+///
+/// ```
+/// use petgraph::stable_graph::StableDiGraph;
+/// use petgraph_live::hebbian::{sokm_tick, SokmConfig, HebbianReport};
+///
+/// let mut g = StableDiGraph::<(), f64>::new();
+/// let a = g.add_node(());
+/// let b = g.add_node(());
+/// g.add_edge(a, b, 0.5);
+///
+/// let report = sokm_tick(&mut g, &[(a, 1.0), (b, 0.8)], &SokmConfig::default());
+/// assert_eq!(report.decayed, 1);
+/// assert!(report.strengthened > 0);
+/// ```
+pub fn sokm_tick<N>(
+    graph: &mut StableDiGraph<N, f64>,
+    activated: &[(NodeIndex, f64)],
+    config: &SokmConfig,
+) -> HebbianReport {
+    let decayed = decay(graph, config.decay_factor);
+    let strengthened = strengthen(graph, activated, config);
+    let pruned = prune(graph, config.min_weight);
+    HebbianReport {
+        decayed,
+        strengthened,
+        pruned,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_graph() -> StableDiGraph<(), f64> {
+        let mut g = StableDiGraph::new();
+        let a = g.add_node(());
+        let b = g.add_node(());
+        let c = g.add_node(());
+        g.add_edge(a, b, 0.5);
+        g.add_edge(b, c, 0.3);
+        g.add_edge(a, c, 0.01);
+        g
+    }
+
+    #[test]
+    fn decay_multiplies_all_weights() {
+        let mut g = make_graph();
+        assert_eq!(decay(&mut g, 0.5), 3);
+        assert_eq!(*g.edge_weight(0.into()).unwrap(), 0.25);
+        assert_eq!(*g.edge_weight(1.into()).unwrap(), 0.15);
+    }
+
+    #[test]
+    fn prune_removes_below_threshold() {
+        let mut g = make_graph();
+        assert_eq!(prune(&mut g, 0.1), 1); // removes 0.01 edge
+        assert_eq!(g.edge_count(), 2);
+    }
+
+    #[test]
+    fn strengthen_creates_missing_edges() {
+        let mut g = StableDiGraph::<(), f64>::new();
+        let a = g.add_node(());
+        let b = g.add_node(());
+        assert_eq!(g.edge_count(), 0);
+
+        let config = SokmConfig::default();
+        strengthen(&mut g, &[(a, 1.0), (b, 1.0)], &config);
+        assert_eq!(g.edge_count(), 2); // a→b and b→a
+    }
+
+    #[test]
+    fn strengthen_increments_existing_edge() {
+        let mut g = StableDiGraph::<(), f64>::new();
+        let a = g.add_node(());
+        let b = g.add_node(());
+        g.add_edge(a, b, 0.5);
+
+        let config = SokmConfig::default();
+        strengthen(&mut g, &[(a, 1.0), (b, 1.0)], &config);
+        // 0.5 + 0.02*1.0*1.0 = 0.52
+        assert!((g.edge_weight(0.into()).unwrap() - 0.52).abs() < 1e-10);
+    }
+
+    #[test]
+    fn sokm_tick_full_cycle() {
+        let mut g = StableDiGraph::<(), f64>::new();
+        let a = g.add_node(());
+        let b = g.add_node(());
+        g.add_edge(a, b, 0.0005); // will be pruned after decay
+
+        let config = SokmConfig::default();
+        let report = sokm_tick(&mut g, &[(a, 1.0), (b, 1.0)], &config);
+        assert_eq!(report.decayed, 1);
+        assert_eq!(report.strengthened, 2);
+        // 0.0005 * 0.95 = 0.000475, then +0.02 = 0.020475, not pruned
+        // But b→a is newly created at 0.02, not pruned either
+        assert_eq!(report.pruned, 0);
+    }
+
+    #[test]
+    fn sokm_tick_prunes_weak_edge() {
+        let mut g = StableDiGraph::<(), f64>::new();
+        let a = g.add_node(());
+        let b = g.add_node(());
+        let c = g.add_node(());
+        g.add_edge(a, c, 0.0005); // decays to 0.000475, no co-activation → pruned
+
+        let config = SokmConfig::default();
+        let report = sokm_tick(&mut g, &[(a, 1.0), (b, 1.0)], &config);
+        assert_eq!(report.pruned, 1);
+    }
+
+    #[test]
+    fn strength_formula_min() {
+        let mut g = StableDiGraph::<(), f64>::new();
+        let a = g.add_node(());
+        let b = g.add_node(());
+
+        let config = SokmConfig {
+            formula: StrengthFormula::Min,
+            ..SokmConfig::default()
+        };
+        strengthen(&mut g, &[(a, 0.8), (b, 0.3)], &config);
+        // delta * min(0.8, 0.3) = 0.02 * 0.3 = 0.006
+        assert!((g.edge_weight(0.into()).unwrap() - 0.006).abs() < 1e-10);
+    }
+
+    #[test]
+    fn strength_formula_average() {
+        let mut g = StableDiGraph::<(), f64>::new();
+        let a = g.add_node(());
+        let b = g.add_node(());
+
+        let config = SokmConfig {
+            formula: StrengthFormula::Average,
+            ..SokmConfig::default()
+        };
+        strengthen(&mut g, &[(a, 0.8), (b, 0.4)], &config);
+        // delta * (0.8 + 0.4) / 2 = 0.02 * 0.6 = 0.012
+        assert!((g.edge_weight(0.into()).unwrap() - 0.012).abs() < 1e-10);
+    }
+}

--- a/src/hebbian/stdp.rs
+++ b/src/hebbian/stdp.rs
@@ -1,0 +1,212 @@
+//! STDP (Spike-Timing Dependent Plasticity) — temporal Hebbian rule.
+//!
+//! Strengthening depends on *order* of activation: causal pairs (pre fires
+//! before post) are strengthened, anti-causal pairs are weakened.
+
+use petgraph::EdgeType;
+use petgraph::graph::NodeIndex;
+use petgraph::stable_graph::StableGraph;
+
+/// STDP configuration.
+#[derive(Debug, Clone, Copy)]
+pub struct StdpConfig {
+    /// Strengthening amplitude for causal order (pre fires before post).
+    pub a_plus: f64,
+    /// Weakening amplitude for anti-causal order (post fires before pre).
+    pub a_minus: f64,
+    /// Time constant for causal window (ticks).
+    pub tau_plus: f64,
+    /// Time constant for anti-causal window (ticks).
+    pub tau_minus: f64,
+}
+
+impl Default for StdpConfig {
+    fn default() -> Self {
+        Self {
+            a_plus: 0.01,
+            a_minus: 0.005,
+            tau_plus: 5.0,
+            tau_minus: 5.0,
+        }
+    }
+}
+
+/// Activation with timing: (node, score, tick_fired).
+pub type TimedActivation = (NodeIndex, f64, u64);
+
+/// Apply STDP rule to edges between nodes that fired in the given window.
+///
+/// For each directed edge (pre → post) where both endpoints fired:
+/// - If pre fired before post (causal): Δw = +a_plus × exp(-Δt / tau_plus)
+/// - If post fired before pre (anti-causal): Δw = -a_minus × exp(-Δt / tau_minus)
+/// - If same tick: no change
+///
+/// Creates edges for causal pairs if none exists. Returns number of edges modified.
+///
+/// # Examples
+///
+/// ```
+/// use petgraph::stable_graph::StableDiGraph;
+/// use petgraph_live::hebbian::{stdp_update, StdpConfig};
+///
+/// let mut g = StableDiGraph::<(), f64>::new();
+/// let a = g.add_node(());
+/// let b = g.add_node(());
+/// g.add_edge(a, b, 0.5);
+///
+/// // a fires at tick 1, b fires at tick 3 → a→b is causal (strengthened)
+/// let activations = vec![(a, 1.0, 1), (b, 1.0, 3)];
+/// let modified = stdp_update(&mut g, &activations, &StdpConfig::default());
+/// assert!(modified > 0);
+/// assert!(*g.edge_weight(0.into()).unwrap() > 0.5);
+/// ```
+pub fn stdp_update<N, Ty: EdgeType>(
+    graph: &mut StableGraph<N, f64, Ty>,
+    activations: &[TimedActivation],
+    config: &StdpConfig,
+) -> usize {
+    let mut modified = 0;
+    for i in 0..activations.len() {
+        let j_start = if Ty::is_directed() { 0 } else { i + 1 };
+        for j in j_start..activations.len() {
+            if i == j {
+                continue;
+            }
+            let (ni, _si, ti) = activations[i];
+            let (nj, _sj, tj) = activations[j];
+            if ti == tj {
+                continue;
+            }
+
+            // For directed: consider edge i→j
+            // pre=i, post=j: if ti < tj → causal, else anti-causal
+            let dt = (tj as f64) - (ti as f64);
+            let delta_w = if dt > 0.0 {
+                config.a_plus * (-dt / config.tau_plus).exp()
+            } else {
+                -config.a_minus * (dt / config.tau_minus).exp()
+            };
+
+            if let Some(idx) = graph.find_edge(ni, nj) {
+                if let Some(w) = graph.edge_weight_mut(idx) {
+                    *w += delta_w;
+                    modified += 1;
+                }
+            } else if delta_w > 0.0 {
+                graph.add_edge(ni, nj, delta_w);
+                modified += 1;
+            }
+
+            // For directed graphs, also process j→i edge
+            if Ty::is_directed() {
+                let delta_w_rev = -delta_w; // reversed direction
+                if let Some(idx) = graph.find_edge(nj, ni) {
+                    if let Some(w) = graph.edge_weight_mut(idx) {
+                        *w += delta_w_rev;
+                        modified += 1;
+                    }
+                } else if delta_w_rev > 0.0 {
+                    graph.add_edge(nj, ni, delta_w_rev);
+                    modified += 1;
+                }
+            }
+        }
+    }
+    modified
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use petgraph::stable_graph::{StableDiGraph, StableUnGraph};
+
+    #[test]
+    fn causal_pair_strengthened() {
+        let mut g = StableDiGraph::<(), f64>::new();
+        let a = g.add_node(());
+        let b = g.add_node(());
+        g.add_edge(a, b, 0.5);
+
+        // a fires at tick 1, b fires at tick 2 → a→b is causal
+        stdp_update(&mut g, &[(a, 1.0, 1), (b, 1.0, 2)], &StdpConfig::default());
+        assert!(*g.edge_weight(0.into()).unwrap() > 0.5);
+    }
+
+    #[test]
+    fn anti_causal_pair_weakened() {
+        let mut g = StableDiGraph::<(), f64>::new();
+        let a = g.add_node(());
+        let b = g.add_node(());
+        g.add_edge(a, b, 0.5);
+
+        // b fires at tick 1, a fires at tick 3 → a→b is anti-causal (post fired first)
+        stdp_update(&mut g, &[(a, 1.0, 3), (b, 1.0, 1)], &StdpConfig::default());
+        assert!(*g.edge_weight(0.into()).unwrap() < 0.5);
+    }
+
+    #[test]
+    fn strength_depends_on_time_difference() {
+        let config = StdpConfig::default();
+
+        // Close in time → stronger effect
+        let mut g1 = StableDiGraph::<(), f64>::new();
+        let a1 = g1.add_node(());
+        let b1 = g1.add_node(());
+        g1.add_edge(a1, b1, 0.5);
+        stdp_update(&mut g1, &[(a1, 1.0, 1), (b1, 1.0, 2)], &config);
+        let w_close = *g1.edge_weight(0.into()).unwrap();
+
+        // Far in time → weaker effect
+        let mut g2 = StableDiGraph::<(), f64>::new();
+        let a2 = g2.add_node(());
+        let b2 = g2.add_node(());
+        g2.add_edge(a2, b2, 0.5);
+        stdp_update(&mut g2, &[(a2, 1.0, 1), (b2, 1.0, 10)], &config);
+        let w_far = *g2.edge_weight(0.into()).unwrap();
+
+        assert!(w_close > w_far);
+    }
+
+    #[test]
+    fn beyond_tau_window_minimal_effect() {
+        let config = StdpConfig {
+            tau_plus: 2.0,
+            ..StdpConfig::default()
+        };
+
+        let mut g = StableDiGraph::<(), f64>::new();
+        let a = g.add_node(());
+        let b = g.add_node(());
+        g.add_edge(a, b, 0.5);
+
+        // dt=20, tau=2 → exp(-10) ≈ 0.0000454 → negligible
+        stdp_update(&mut g, &[(a, 1.0, 1), (b, 1.0, 21)], &config);
+        let w = *g.edge_weight(0.into()).unwrap();
+        assert!((w - 0.5).abs() < 0.0001);
+    }
+
+    #[test]
+    fn same_tick_no_change() {
+        let mut g = StableDiGraph::<(), f64>::new();
+        let a = g.add_node(());
+        let b = g.add_node(());
+        g.add_edge(a, b, 0.5);
+
+        let modified = stdp_update(&mut g, &[(a, 1.0, 5), (b, 1.0, 5)], &StdpConfig::default());
+        assert_eq!(modified, 0);
+        assert_eq!(*g.edge_weight(0.into()).unwrap(), 0.5);
+    }
+
+    #[test]
+    fn undirected_stdp() {
+        let mut g = StableUnGraph::<(), f64>::with_capacity(0, 0);
+        let a = g.add_node(());
+        let b = g.add_node(());
+        g.add_edge(a, b, 0.5);
+
+        // a fires before b → causal → strengthen
+        let modified = stdp_update(&mut g, &[(a, 1.0, 1), (b, 1.0, 3)], &StdpConfig::default());
+        assert_eq!(modified, 1);
+        assert!(*g.edge_weight(0.into()).unwrap() > 0.5);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! | Feature | Description |
 //! |---|---|
-//! | *(default)* | [`cache`], [`metrics`], [`connect`], [`shortest_path`], [`mst`] |
+//! | *(default)* | [`cache`], [`metrics`], [`connect`], [`shortest_path`], [`mst`], [`hebbian`] |
 //! | `snapshot` | Disk persistence via bincode or JSON |
 //! | `snapshot-zstd` | Zstd compression for snapshots (implies `snapshot`) |
 //! | `snapshot-lz4` | LZ4 compression via `lz4_flex` (implies `snapshot`) |
@@ -26,6 +26,7 @@
 
 pub mod cache;
 pub mod connect;
+pub mod hebbian;
 pub mod metrics;
 pub mod mst;
 pub mod shortest_path;


### PR DESCRIPTION
## Release v0.4.0

### Added
- `hebbian` module — SOKM, STDP, anti-Hebbian, Oja, BCM — dynamic edge-weight learning on `StableGraph<N, f64, Ty>`
- Criterion benchmarks for all hebbian algorithms
- Examples: `hebbian_sokm`, `hebbian_stdp`, `hebbian_anti`, `hebbian_oja`, `hebbian_bcm`

### Checklist
- [x] All feature matrix tests pass
- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] All examples run without panic
- [x] Doc tests pass
- [x] CHANGELOG dated
- [x] Version bumped to 0.4.0